### PR TITLE
Fix for https://github.com/bripkens/lucene/issues/9

### DIFF
--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -50,7 +50,7 @@
  *     'field': string,         // field name
  *     'term_min': string,      // minimum value (left side) of range
  *     'term_max': string,      // maximum value (right side) of range
- *     'inclusive': boolean     // inclusive ([...]) or exclusive ({...})
+ *     'inclusive': string     // inclusive ([...]) or exclusive ({...}) or mixed ({...],[...})
  * }
  *
  * Other Notes:
@@ -157,6 +157,9 @@ paren_exp
     }
 
 field_exp
+
+
+
   = fieldname:fieldname? range:range_operator_exp
     {
         range['field'] =
@@ -236,6 +239,15 @@ term
         return result;
     }
 
+rterm_char
+  = '.' / [^ \t\r\n\f\{\}()"/^~\[\]]
+
+ranged_term
+  = term:rterm_char+
+    {
+        return term.join('');
+    }
+
 unquoted_term
   = term:term_char+
     {
@@ -307,20 +319,36 @@ int_exp
     }
 
 range_operator_exp
-  = '[' term_min:unquoted_term _* 'TO' _+ term_max:unquoted_term ']'
+  = '[' term_min:ranged_term _* 'TO' _+ term_max:ranged_term ']'
     {
         return {
             'term_min': term_min,
             'term_max': term_max,
-            'inclusive': true
+            'inclusive': 'both'
         };
     }
-  / '{' term_min:unquoted_term _* 'TO' _+ term_max:unquoted_term '}'
+  / '{' term_min:ranged_term _* 'TO' _+ term_max:ranged_term '}'
     {
         return {
             'term_min': term_min,
             'term_max': term_max,
-            'inclusive': false
+            'inclusive': 'none'
+        };
+    }
+  / '[' term_min:ranged_term _* 'TO' _+ term_max:ranged_term '}'
+    {
+        return {
+            'term_min': term_min,
+            'term_max': term_max,
+            'inclusive': 'left'
+        };
+    }
+  / '{' term_min:ranged_term _* 'TO' _+ term_max:ranged_term ']'
+    {
+        return {
+            'term_min': term_min,
+            'term_max': term_max,
+            'inclusive': 'right'
         };
     }
 

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -169,107 +169,123 @@ module.exports = (function() {
                 }
                 return result;
             },
-        peg$c23 = function(term) {
+        peg$c23 = ".",
+        peg$c24 = { type: "literal", value: ".", description: "\".\"" },
+        peg$c25 = /^[^ \t\r\n\f{}()"\/\^~[\]]/,
+        peg$c26 = { type: "class", value: "[^ \\t\\r\\n\\f{}()\"\\/\\^~[\\]]", description: "[^ \\t\\r\\n\\f{}()\"\\/\\^~[\\]]" },
+        peg$c27 = function(term) {
                 return term.join('');
             },
-        peg$c24 = ".",
-        peg$c25 = { type: "literal", value: ".", description: "\".\"" },
-        peg$c26 = /^[^: \t\r\n\f{}()"\/\^~[\]]/,
-        peg$c27 = { type: "class", value: "[^: \\t\\r\\n\\f{}()\"\\/\\^~[\\]]", description: "[^: \\t\\r\\n\\f{}()\"\\/\\^~[\\]]" },
-        peg$c28 = "\"",
-        peg$c29 = { type: "literal", value: "\"", description: "\"\\\"\"" },
-        peg$c30 = function(chars) { return chars.join(''); },
-        peg$c31 = void 0,
-        peg$c32 = "\\",
-        peg$c33 = { type: "literal", value: "\\", description: "\"\\\\\"" },
-        peg$c34 = { type: "any", description: "any character" },
-        peg$c35 = function(char) { return char; },
-        peg$c36 = function(sequence) { return sequence; },
-        peg$c37 = "+",
-        peg$c38 = { type: "literal", value: "+", description: "\"+\"" },
-        peg$c39 = "-",
-        peg$c40 = { type: "literal", value: "-", description: "\"-\"" },
-        peg$c41 = "!",
-        peg$c42 = { type: "literal", value: "!", description: "\"!\"" },
-        peg$c43 = "{",
-        peg$c44 = { type: "literal", value: "{", description: "\"{\"" },
-        peg$c45 = "}",
-        peg$c46 = { type: "literal", value: "}", description: "\"}\"" },
-        peg$c47 = "[",
-        peg$c48 = { type: "literal", value: "[", description: "\"[\"" },
-        peg$c49 = "]",
-        peg$c50 = { type: "literal", value: "]", description: "\"]\"" },
-        peg$c51 = "^",
-        peg$c52 = { type: "literal", value: "^", description: "\"^\"" },
-        peg$c53 = "?",
-        peg$c54 = { type: "literal", value: "?", description: "\"?\"" },
-        peg$c55 = ":",
-        peg$c56 = { type: "literal", value: ":", description: "\":\"" },
-        peg$c57 = "&",
-        peg$c58 = { type: "literal", value: "&", description: "\"&\"" },
-        peg$c59 = "|",
-        peg$c60 = { type: "literal", value: "|", description: "\"|\"" },
-        peg$c61 = "'",
-        peg$c62 = { type: "literal", value: "'", description: "\"'\"" },
-        peg$c63 = "/",
-        peg$c64 = { type: "literal", value: "/", description: "\"/\"" },
-        peg$c65 = "~",
-        peg$c66 = { type: "literal", value: "~", description: "\"~\"" },
-        peg$c67 = function(proximity) {
+        peg$c28 = /^[^: \t\r\n\f{}()"\/\^~[\]]/,
+        peg$c29 = { type: "class", value: "[^: \\t\\r\\n\\f{}()\"\\/\\^~[\\]]", description: "[^: \\t\\r\\n\\f{}()\"\\/\\^~[\\]]" },
+        peg$c30 = "\"",
+        peg$c31 = { type: "literal", value: "\"", description: "\"\\\"\"" },
+        peg$c32 = function(chars) { return chars.join(''); },
+        peg$c33 = void 0,
+        peg$c34 = "\\",
+        peg$c35 = { type: "literal", value: "\\", description: "\"\\\\\"" },
+        peg$c36 = { type: "any", description: "any character" },
+        peg$c37 = function(char) { return char; },
+        peg$c38 = function(sequence) { return sequence; },
+        peg$c39 = "+",
+        peg$c40 = { type: "literal", value: "+", description: "\"+\"" },
+        peg$c41 = "-",
+        peg$c42 = { type: "literal", value: "-", description: "\"-\"" },
+        peg$c43 = "!",
+        peg$c44 = { type: "literal", value: "!", description: "\"!\"" },
+        peg$c45 = "{",
+        peg$c46 = { type: "literal", value: "{", description: "\"{\"" },
+        peg$c47 = "}",
+        peg$c48 = { type: "literal", value: "}", description: "\"}\"" },
+        peg$c49 = "[",
+        peg$c50 = { type: "literal", value: "[", description: "\"[\"" },
+        peg$c51 = "]",
+        peg$c52 = { type: "literal", value: "]", description: "\"]\"" },
+        peg$c53 = "^",
+        peg$c54 = { type: "literal", value: "^", description: "\"^\"" },
+        peg$c55 = "?",
+        peg$c56 = { type: "literal", value: "?", description: "\"?\"" },
+        peg$c57 = ":",
+        peg$c58 = { type: "literal", value: ":", description: "\":\"" },
+        peg$c59 = "&",
+        peg$c60 = { type: "literal", value: "&", description: "\"&\"" },
+        peg$c61 = "|",
+        peg$c62 = { type: "literal", value: "|", description: "\"|\"" },
+        peg$c63 = "'",
+        peg$c64 = { type: "literal", value: "'", description: "\"'\"" },
+        peg$c65 = "/",
+        peg$c66 = { type: "literal", value: "/", description: "\"/\"" },
+        peg$c67 = "~",
+        peg$c68 = { type: "literal", value: "~", description: "\"~\"" },
+        peg$c69 = function(proximity) {
                 return proximity;
             },
-        peg$c68 = function(boost) {
+        peg$c70 = function(boost) {
                 return boost;
             },
-        peg$c69 = function(fuzziness) {
+        peg$c71 = function(fuzziness) {
                 return fuzziness == '' || fuzziness == null ? 0.5 : fuzziness;
             },
-        peg$c70 = "0.",
-        peg$c71 = { type: "literal", value: "0.", description: "\"0.\"" },
-        peg$c72 = /^[0-9]/,
-        peg$c73 = { type: "class", value: "[0-9]", description: "[0-9]" },
-        peg$c74 = function(val) {
+        peg$c72 = "0.",
+        peg$c73 = { type: "literal", value: "0.", description: "\"0.\"" },
+        peg$c74 = /^[0-9]/,
+        peg$c75 = { type: "class", value: "[0-9]", description: "[0-9]" },
+        peg$c76 = function(val) {
                 return parseFloat("0." + val.join(''));
             },
-        peg$c75 = function(val) {
+        peg$c77 = function(val) {
                 return parseInt(val.join(''));
             },
-        peg$c76 = "TO",
-        peg$c77 = { type: "literal", value: "TO", description: "\"TO\"" },
-        peg$c78 = function(term_min, term_max) {
+        peg$c78 = "TO",
+        peg$c79 = { type: "literal", value: "TO", description: "\"TO\"" },
+        peg$c80 = function(term_min, term_max) {
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
-                    'inclusive': true
+                    'inclusive': 'both'
                 };
             },
-        peg$c79 = function(term_min, term_max) {
+        peg$c81 = function(term_min, term_max) {
                 return {
                     'term_min': term_min,
                     'term_max': term_max,
-                    'inclusive': false
+                    'inclusive': 'none'
                 };
             },
-        peg$c80 = function(operator) {
+        peg$c82 = function(term_min, term_max) {
+                return {
+                    'term_min': term_min,
+                    'term_max': term_max,
+                    'inclusive': 'left'
+                };
+            },
+        peg$c83 = function(term_min, term_max) {
+                return {
+                    'term_min': term_min,
+                    'term_max': term_max,
+                    'inclusive': 'right'
+                };
+            },
+        peg$c84 = function(operator) {
                 return operator;
             },
-        peg$c81 = "OR NOT",
-        peg$c82 = { type: "literal", value: "OR NOT", description: "\"OR NOT\"" },
-        peg$c83 = "AND NOT",
-        peg$c84 = { type: "literal", value: "AND NOT", description: "\"AND NOT\"" },
-        peg$c85 = "OR",
-        peg$c86 = { type: "literal", value: "OR", description: "\"OR\"" },
-        peg$c87 = "AND",
-        peg$c88 = { type: "literal", value: "AND", description: "\"AND\"" },
-        peg$c89 = "NOT",
-        peg$c90 = { type: "literal", value: "NOT", description: "\"NOT\"" },
-        peg$c91 = "||",
-        peg$c92 = { type: "literal", value: "||", description: "\"||\"" },
-        peg$c93 = "&&",
-        peg$c94 = { type: "literal", value: "&&", description: "\"&&\"" },
-        peg$c95 = { type: "other", description: "whitespace" },
-        peg$c96 = /^[ \t\r\n\f]/,
-        peg$c97 = { type: "class", value: "[ \\t\\r\\n\\f]", description: "[ \\t\\r\\n\\f]" },
+        peg$c85 = "OR NOT",
+        peg$c86 = { type: "literal", value: "OR NOT", description: "\"OR NOT\"" },
+        peg$c87 = "AND NOT",
+        peg$c88 = { type: "literal", value: "AND NOT", description: "\"AND NOT\"" },
+        peg$c89 = "OR",
+        peg$c90 = { type: "literal", value: "OR", description: "\"OR\"" },
+        peg$c91 = "AND",
+        peg$c92 = { type: "literal", value: "AND", description: "\"AND\"" },
+        peg$c93 = "NOT",
+        peg$c94 = { type: "literal", value: "NOT", description: "\"NOT\"" },
+        peg$c95 = "||",
+        peg$c96 = { type: "literal", value: "||", description: "\"||\"" },
+        peg$c97 = "&&",
+        peg$c98 = { type: "literal", value: "&&", description: "\"&&\"" },
+        peg$c99 = { type: "other", description: "whitespace" },
+        peg$c100 = /^[ \t\r\n\f]/,
+        peg$c101 = { type: "class", value: "[ \\t\\r\\n\\f]", description: "[ \\t\\r\\n\\f]" },
 
         peg$currPos          = 0,
         peg$reportedPos      = 0,
@@ -903,6 +919,52 @@ module.exports = (function() {
       return s0;
     }
 
+    function peg$parserterm_char() {
+      var s0;
+
+      if (input.charCodeAt(peg$currPos) === 46) {
+        s0 = peg$c23;
+        peg$currPos++;
+      } else {
+        s0 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c24); }
+      }
+      if (s0 === peg$FAILED) {
+        if (peg$c25.test(input.charAt(peg$currPos))) {
+          s0 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c26); }
+        }
+      }
+
+      return s0;
+    }
+
+    function peg$parseranged_term() {
+      var s0, s1, s2;
+
+      s0 = peg$currPos;
+      s1 = [];
+      s2 = peg$parserterm_char();
+      if (s2 !== peg$FAILED) {
+        while (s2 !== peg$FAILED) {
+          s1.push(s2);
+          s2 = peg$parserterm_char();
+        }
+      } else {
+        s1 = peg$c0;
+      }
+      if (s1 !== peg$FAILED) {
+        peg$reportedPos = s0;
+        s1 = peg$c27(s1);
+      }
+      s0 = s1;
+
+      return s0;
+    }
+
     function peg$parseunquoted_term() {
       var s0, s1, s2;
 
@@ -919,7 +981,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c23(s1);
+        s1 = peg$c27(s1);
       }
       s0 = s1;
 
@@ -930,19 +992,19 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c24;
+        s0 = peg$c23;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c25); }
+        if (peg$silentFails === 0) { peg$fail(peg$c24); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c26.test(input.charAt(peg$currPos))) {
+        if (peg$c28.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c27); }
+          if (peg$silentFails === 0) { peg$fail(peg$c29); }
         }
       }
 
@@ -954,11 +1016,11 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s1 = peg$c28;
+        s1 = peg$c30;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+        if (peg$silentFails === 0) { peg$fail(peg$c31); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
@@ -969,15 +1031,15 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 34) {
-            s3 = peg$c28;
+            s3 = peg$c30;
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+            if (peg$silentFails === 0) { peg$fail(peg$c31); }
           }
           if (s3 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c30(s2);
+            s1 = peg$c32(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1002,24 +1064,24 @@ module.exports = (function() {
       s1 = peg$currPos;
       peg$silentFails++;
       if (input.charCodeAt(peg$currPos) === 34) {
-        s2 = peg$c28;
+        s2 = peg$c30;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c29); }
+        if (peg$silentFails === 0) { peg$fail(peg$c31); }
       }
       if (s2 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 92) {
-          s2 = peg$c32;
+          s2 = peg$c34;
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c33); }
+          if (peg$silentFails === 0) { peg$fail(peg$c35); }
         }
       }
       peg$silentFails--;
       if (s2 === peg$FAILED) {
-        s1 = peg$c31;
+        s1 = peg$c33;
       } else {
         peg$currPos = s1;
         s1 = peg$c0;
@@ -1030,11 +1092,11 @@ module.exports = (function() {
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c34); }
+          if (peg$silentFails === 0) { peg$fail(peg$c36); }
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c35(s2);
+          s1 = peg$c37(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1047,17 +1109,17 @@ module.exports = (function() {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 92) {
-          s1 = peg$c32;
+          s1 = peg$c34;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c33); }
+          if (peg$silentFails === 0) { peg$fail(peg$c35); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseEscapeSequence();
           if (s2 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c36(s2);
+            s1 = peg$c38(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1076,27 +1138,27 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 43) {
-        s0 = peg$c37;
+        s0 = peg$c39;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c38); }
+        if (peg$silentFails === 0) { peg$fail(peg$c40); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s0 = peg$c39;
+          s0 = peg$c41;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c40); }
+          if (peg$silentFails === 0) { peg$fail(peg$c42); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 33) {
-            s0 = peg$c41;
+            s0 = peg$c43;
             peg$currPos++;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c42); }
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
           }
           if (s0 === peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 40) {
@@ -1116,107 +1178,107 @@ module.exports = (function() {
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 123) {
-                  s0 = peg$c43;
+                  s0 = peg$c45;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c46); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 125) {
-                    s0 = peg$c45;
+                    s0 = peg$c47;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c46); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c48); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 91) {
-                      s0 = peg$c47;
+                      s0 = peg$c49;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c48); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c50); }
                     }
                     if (s0 === peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 93) {
-                        s0 = peg$c49;
+                        s0 = peg$c51;
                         peg$currPos++;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c52); }
                       }
                       if (s0 === peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 94) {
-                          s0 = peg$c51;
+                          s0 = peg$c53;
                           peg$currPos++;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c52); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c54); }
                         }
                         if (s0 === peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 34) {
-                            s0 = peg$c28;
+                            s0 = peg$c30;
                             peg$currPos++;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c29); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c31); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 63) {
-                              s0 = peg$c53;
+                              s0 = peg$c55;
                               peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c54); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c56); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 58) {
-                                s0 = peg$c55;
+                                s0 = peg$c57;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c56); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c58); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 92) {
-                                  s0 = peg$c32;
+                                  s0 = peg$c34;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c33); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c35); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 38) {
-                                    s0 = peg$c57;
+                                    s0 = peg$c59;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c58); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c60); }
                                   }
                                   if (s0 === peg$FAILED) {
                                     if (input.charCodeAt(peg$currPos) === 124) {
-                                      s0 = peg$c59;
+                                      s0 = peg$c61;
                                       peg$currPos++;
                                     } else {
                                       s0 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c60); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c62); }
                                     }
                                     if (s0 === peg$FAILED) {
                                       if (input.charCodeAt(peg$currPos) === 39) {
-                                        s0 = peg$c61;
+                                        s0 = peg$c63;
                                         peg$currPos++;
                                       } else {
                                         s0 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c62); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c64); }
                                       }
                                       if (s0 === peg$FAILED) {
                                         if (input.charCodeAt(peg$currPos) === 47) {
-                                          s0 = peg$c63;
+                                          s0 = peg$c65;
                                           peg$currPos++;
                                         } else {
                                           s0 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c64); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c66); }
                                         }
                                       }
                                     }
@@ -1244,17 +1306,17 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 126) {
-        s1 = peg$c65;
+        s1 = peg$c67;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c66); }
+        if (peg$silentFails === 0) { peg$fail(peg$c68); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseint_exp();
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c67(s2);
+          s1 = peg$c69(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1273,17 +1335,17 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 94) {
-        s1 = peg$c51;
+        s1 = peg$c53;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c52); }
+        if (peg$silentFails === 0) { peg$fail(peg$c54); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsedecimal_or_int_exp();
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c68(s2);
+          s1 = peg$c70(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1302,11 +1364,11 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 126) {
-        s1 = peg$c65;
+        s1 = peg$c67;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c66); }
+        if (peg$silentFails === 0) { peg$fail(peg$c68); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parsedecimal_exp();
@@ -1315,7 +1377,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c69(s2);
+          s1 = peg$c71(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1344,31 +1406,31 @@ module.exports = (function() {
       var s0, s1, s2, s3;
 
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 2) === peg$c70) {
-        s1 = peg$c70;
+      if (input.substr(peg$currPos, 2) === peg$c72) {
+        s1 = peg$c72;
         peg$currPos += 2;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c71); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s1 !== peg$FAILED) {
         s2 = [];
-        if (peg$c72.test(input.charAt(peg$currPos))) {
+        if (peg$c74.test(input.charAt(peg$currPos))) {
           s3 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c73); }
+          if (peg$silentFails === 0) { peg$fail(peg$c75); }
         }
         if (s3 !== peg$FAILED) {
           while (s3 !== peg$FAILED) {
             s2.push(s3);
-            if (peg$c72.test(input.charAt(peg$currPos))) {
+            if (peg$c74.test(input.charAt(peg$currPos))) {
               s3 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c73); }
+              if (peg$silentFails === 0) { peg$fail(peg$c75); }
             }
           }
         } else {
@@ -1376,7 +1438,7 @@ module.exports = (function() {
         }
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c74(s2);
+          s1 = peg$c76(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1395,22 +1457,22 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       s1 = [];
-      if (peg$c72.test(input.charAt(peg$currPos))) {
+      if (peg$c74.test(input.charAt(peg$currPos))) {
         s2 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c73); }
+        if (peg$silentFails === 0) { peg$fail(peg$c75); }
       }
       if (s2 !== peg$FAILED) {
         while (s2 !== peg$FAILED) {
           s1.push(s2);
-          if (peg$c72.test(input.charAt(peg$currPos))) {
+          if (peg$c74.test(input.charAt(peg$currPos))) {
             s2 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s2 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c73); }
+            if (peg$silentFails === 0) { peg$fail(peg$c75); }
           }
         }
       } else {
@@ -1418,7 +1480,7 @@ module.exports = (function() {
       }
       if (s1 !== peg$FAILED) {
         peg$reportedPos = s0;
-        s1 = peg$c75(s1);
+        s1 = peg$c77(s1);
       }
       s0 = s1;
 
@@ -1430,14 +1492,14 @@ module.exports = (function() {
 
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 91) {
-        s1 = peg$c47;
+        s1 = peg$c49;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c48); }
+        if (peg$silentFails === 0) { peg$fail(peg$c50); }
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseunquoted_term();
+        s2 = peg$parseranged_term();
         if (s2 !== peg$FAILED) {
           s3 = [];
           s4 = peg$parse_();
@@ -1446,12 +1508,12 @@ module.exports = (function() {
             s4 = peg$parse_();
           }
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c76) {
-              s4 = peg$c76;
+            if (input.substr(peg$currPos, 2) === peg$c78) {
+              s4 = peg$c78;
               peg$currPos += 2;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c77); }
+              if (peg$silentFails === 0) { peg$fail(peg$c79); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -1465,18 +1527,18 @@ module.exports = (function() {
                 s5 = peg$c0;
               }
               if (s5 !== peg$FAILED) {
-                s6 = peg$parseunquoted_term();
+                s6 = peg$parseranged_term();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 93) {
-                    s7 = peg$c49;
+                    s7 = peg$c51;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c50); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c52); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$reportedPos = s0;
-                    s1 = peg$c78(s2, s6);
+                    s1 = peg$c80(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1509,14 +1571,14 @@ module.exports = (function() {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 123) {
-          s1 = peg$c43;
+          s1 = peg$c45;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          if (peg$silentFails === 0) { peg$fail(peg$c46); }
         }
         if (s1 !== peg$FAILED) {
-          s2 = peg$parseunquoted_term();
+          s2 = peg$parseranged_term();
           if (s2 !== peg$FAILED) {
             s3 = [];
             s4 = peg$parse_();
@@ -1525,12 +1587,12 @@ module.exports = (function() {
               s4 = peg$parse_();
             }
             if (s3 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c76) {
-                s4 = peg$c76;
+              if (input.substr(peg$currPos, 2) === peg$c78) {
+                s4 = peg$c78;
                 peg$currPos += 2;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c77); }
+                if (peg$silentFails === 0) { peg$fail(peg$c79); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = [];
@@ -1544,18 +1606,18 @@ module.exports = (function() {
                   s5 = peg$c0;
                 }
                 if (s5 !== peg$FAILED) {
-                  s6 = peg$parseunquoted_term();
+                  s6 = peg$parseranged_term();
                   if (s6 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s7 = peg$c45;
+                      s7 = peg$c47;
                       peg$currPos++;
                     } else {
                       s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c46); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c48); }
                     }
                     if (s7 !== peg$FAILED) {
                       peg$reportedPos = s0;
-                      s1 = peg$c79(s2, s6);
+                      s1 = peg$c81(s2, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1584,6 +1646,166 @@ module.exports = (function() {
         } else {
           peg$currPos = s0;
           s0 = peg$c0;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 91) {
+            s1 = peg$c49;
+            peg$currPos++;
+          } else {
+            s1 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c50); }
+          }
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parseranged_term();
+            if (s2 !== peg$FAILED) {
+              s3 = [];
+              s4 = peg$parse_();
+              while (s4 !== peg$FAILED) {
+                s3.push(s4);
+                s4 = peg$parse_();
+              }
+              if (s3 !== peg$FAILED) {
+                if (input.substr(peg$currPos, 2) === peg$c78) {
+                  s4 = peg$c78;
+                  peg$currPos += 2;
+                } else {
+                  s4 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                }
+                if (s4 !== peg$FAILED) {
+                  s5 = [];
+                  s6 = peg$parse_();
+                  if (s6 !== peg$FAILED) {
+                    while (s6 !== peg$FAILED) {
+                      s5.push(s6);
+                      s6 = peg$parse_();
+                    }
+                  } else {
+                    s5 = peg$c0;
+                  }
+                  if (s5 !== peg$FAILED) {
+                    s6 = peg$parseranged_term();
+                    if (s6 !== peg$FAILED) {
+                      if (input.charCodeAt(peg$currPos) === 125) {
+                        s7 = peg$c47;
+                        peg$currPos++;
+                      } else {
+                        s7 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c48); }
+                      }
+                      if (s7 !== peg$FAILED) {
+                        peg$reportedPos = s0;
+                        s1 = peg$c82(s2, s6);
+                        s0 = s1;
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$c0;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$c0;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$c0;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$c0;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c0;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c0;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c0;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$currPos;
+            if (input.charCodeAt(peg$currPos) === 123) {
+              s1 = peg$c45;
+              peg$currPos++;
+            } else {
+              s1 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c46); }
+            }
+            if (s1 !== peg$FAILED) {
+              s2 = peg$parseranged_term();
+              if (s2 !== peg$FAILED) {
+                s3 = [];
+                s4 = peg$parse_();
+                while (s4 !== peg$FAILED) {
+                  s3.push(s4);
+                  s4 = peg$parse_();
+                }
+                if (s3 !== peg$FAILED) {
+                  if (input.substr(peg$currPos, 2) === peg$c78) {
+                    s4 = peg$c78;
+                    peg$currPos += 2;
+                  } else {
+                    s4 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c79); }
+                  }
+                  if (s4 !== peg$FAILED) {
+                    s5 = [];
+                    s6 = peg$parse_();
+                    if (s6 !== peg$FAILED) {
+                      while (s6 !== peg$FAILED) {
+                        s5.push(s6);
+                        s6 = peg$parse_();
+                      }
+                    } else {
+                      s5 = peg$c0;
+                    }
+                    if (s5 !== peg$FAILED) {
+                      s6 = peg$parseranged_term();
+                      if (s6 !== peg$FAILED) {
+                        if (input.charCodeAt(peg$currPos) === 93) {
+                          s7 = peg$c51;
+                          peg$currPos++;
+                        } else {
+                          s7 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c52); }
+                        }
+                        if (s7 !== peg$FAILED) {
+                          peg$reportedPos = s0;
+                          s1 = peg$c83(s2, s6);
+                          s0 = s1;
+                        } else {
+                          peg$currPos = s0;
+                          s0 = peg$c0;
+                        }
+                      } else {
+                        peg$currPos = s0;
+                        s0 = peg$c0;
+                      }
+                    } else {
+                      peg$currPos = s0;
+                      s0 = peg$c0;
+                    }
+                  } else {
+                    peg$currPos = s0;
+                    s0 = peg$c0;
+                  }
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$c0;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c0;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c0;
+            }
+          }
         }
       }
 
@@ -1615,7 +1837,7 @@ module.exports = (function() {
           }
           if (s3 !== peg$FAILED) {
             peg$reportedPos = s0;
-            s1 = peg$c80(s2);
+            s1 = peg$c84(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -1643,7 +1865,7 @@ module.exports = (function() {
             s3 = peg$parseEOF();
             if (s3 !== peg$FAILED) {
               peg$reportedPos = s0;
-              s1 = peg$c80(s2);
+              s1 = peg$c84(s2);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -1665,68 +1887,68 @@ module.exports = (function() {
     function peg$parseoperator() {
       var s0;
 
-      if (input.substr(peg$currPos, 6) === peg$c81) {
-        s0 = peg$c81;
+      if (input.substr(peg$currPos, 6) === peg$c85) {
+        s0 = peg$c85;
         peg$currPos += 6;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c82); }
+        if (peg$silentFails === 0) { peg$fail(peg$c86); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 7) === peg$c83) {
-          s0 = peg$c83;
+        if (input.substr(peg$currPos, 7) === peg$c87) {
+          s0 = peg$c87;
           peg$currPos += 7;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c84); }
+          if (peg$silentFails === 0) { peg$fail(peg$c88); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c85) {
-            s0 = peg$c85;
+          if (input.substr(peg$currPos, 2) === peg$c89) {
+            s0 = peg$c89;
             peg$currPos += 2;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c86); }
+            if (peg$silentFails === 0) { peg$fail(peg$c90); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 3) === peg$c87) {
-              s0 = peg$c87;
+            if (input.substr(peg$currPos, 3) === peg$c91) {
+              s0 = peg$c91;
               peg$currPos += 3;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c88); }
+              if (peg$silentFails === 0) { peg$fail(peg$c92); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 3) === peg$c89) {
-                s0 = peg$c89;
+              if (input.substr(peg$currPos, 3) === peg$c93) {
+                s0 = peg$c93;
                 peg$currPos += 3;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c90); }
+                if (peg$silentFails === 0) { peg$fail(peg$c94); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c91) {
-                  s0 = peg$c91;
+                if (input.substr(peg$currPos, 2) === peg$c95) {
+                  s0 = peg$c95;
                   peg$currPos += 2;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c92); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c96); }
                 }
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c93) {
-                    s0 = peg$c93;
+                  if (input.substr(peg$currPos, 2) === peg$c97) {
+                    s0 = peg$c97;
                     peg$currPos += 2;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c94); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c98); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 33) {
-                      s0 = peg$c41;
+                      s0 = peg$c43;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c42); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c44); }
                     }
                   }
                 }
@@ -1753,7 +1975,7 @@ module.exports = (function() {
         s2 = peg$parseprefix_operator();
         if (s2 !== peg$FAILED) {
           peg$reportedPos = s0;
-          s1 = peg$c80(s2);
+          s1 = peg$c84(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1771,19 +1993,19 @@ module.exports = (function() {
       var s0;
 
       if (input.charCodeAt(peg$currPos) === 43) {
-        s0 = peg$c37;
+        s0 = peg$c39;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c38); }
+        if (peg$silentFails === 0) { peg$fail(peg$c40); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 45) {
-          s0 = peg$c39;
+          s0 = peg$c41;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c40); }
+          if (peg$silentFails === 0) { peg$fail(peg$c42); }
         }
       }
 
@@ -1795,22 +2017,22 @@ module.exports = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c96.test(input.charAt(peg$currPos))) {
+      if (peg$c100.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c97); }
+        if (peg$silentFails === 0) { peg$fail(peg$c101); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c96.test(input.charAt(peg$currPos))) {
+          if (peg$c100.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c97); }
+            if (peg$silentFails === 0) { peg$fail(peg$c101); }
           }
         }
       } else {
@@ -1819,7 +2041,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c95); }
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
       }
 
       return s0;
@@ -1835,11 +2057,11 @@ module.exports = (function() {
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c34); }
+        if (peg$silentFails === 0) { peg$fail(peg$c36); }
       }
       peg$silentFails--;
       if (s1 === peg$FAILED) {
-        s0 = peg$c31;
+        s0 = peg$c33;
       } else {
         peg$currPos = s0;
         s0 = peg$c0;

--- a/lib/toString.js
+++ b/lib/toString.js
@@ -24,7 +24,7 @@ module.exports = function toString(ast) {
       result += '(';
     }
     result += toString(ast.left);
-    
+
     if (ast.parenthesized && !ast.right) {
       result += ')';
     }
@@ -73,7 +73,7 @@ module.exports = function toString(ast) {
   }
 
   if (ast.term_min) {
-    if (ast.inclusive) {
+    if (['both','left'].includes(ast.inclusive)) {
       result += '[';
     } else {
       result += '{';
@@ -83,7 +83,7 @@ module.exports = function toString(ast) {
     result += ' TO ';
     result += ast.term_max;
 
-    if (ast.inclusive) {
+    if (['both','right'].includes(ast.inclusive)) {
       result += ']';
     } else {
       result += '}';

--- a/lib/toString.js
+++ b/lib/toString.js
@@ -73,7 +73,7 @@ module.exports = function toString(ast) {
   }
 
   if (ast.term_min) {
-    if (['both','left'].includes(ast.inclusive)) {
+    if (ast.inclusive === 'both' || ast.inclusive === 'left') {
       result += '[';
     } else {
       result += '{';
@@ -83,7 +83,7 @@ module.exports = function toString(ast) {
     result += ' TO ';
     result += ast.term_max;
 
-    if (['both','right'].includes(ast.inclusive)) {
+    if (ast.inclusive === 'both' || ast.inclusive === 'right') {
       result += ']';
     } else {
       result += '}';

--- a/test/queryParser_test.js
+++ b/test/queryParser_test.js
@@ -256,7 +256,7 @@ describe('queryParser', () => {
       expect(results['left']['field']).to.equal('foo');
       expect(results['left']['term_min']).to.equal('bar');
       expect(results['left']['term_max']).to.equal('baz');
-      expect(results['left']['inclusive']).to.equal(true);
+      expect(results['left']['inclusive']).to.equal('both');
     });
 
     it('parses exclusive range expression', () => {
@@ -265,7 +265,34 @@ describe('queryParser', () => {
       expect(results['left']['field']).to.equal('foo');
       expect(results['left']['term_min']).to.equal('bar');
       expect(results['left']['term_max']).to.equal('baz');
-      expect(results['left']['inclusive']).to.equal(false);
+      expect(results['left']['inclusive']).to.equal('none');
+    });
+
+    it('parses mixed range expression (left inclusive)', () => {
+      var results = lucene.parse('foo:[bar TO baz}');
+
+      expect(results['left']['field']).to.equal('foo');
+      expect(results['left']['term_min']).to.equal('bar');
+      expect(results['left']['term_max']).to.equal('baz');
+      expect(results['left']['inclusive']).to.equal('left');
+    });
+
+    it('parses mixed range expression (right inclusive)', () => {
+      var results = lucene.parse('foo:{bar TO baz]');
+
+      expect(results['left']['field']).to.equal('foo');
+      expect(results['left']['term_min']).to.equal('bar');
+      expect(results['left']['term_max']).to.equal('baz');
+      expect(results['left']['inclusive']).to.equal('right');
+    });
+
+    it('parses mixed range expression (right inclusive) with date ISO format', () => {
+      var results = lucene.parse('date:{2017-11-17T01:32:45.123Z TO 2017-11-18T04:28:11.999Z]');
+
+      expect(results['left']['field']).to.equal('date');
+      expect(results['left']['term_min']).to.equal('2017-11-17T01:32:45.123Z');
+      expect(results['left']['term_max']).to.equal('2017-11-18T04:28:11.999Z');
+      expect(results['left']['inclusive']).to.equal('right');
     });
   });
 
@@ -393,7 +420,7 @@ describe('queryParser', () => {
       expect(results['left']['field']).to.equal('mod_date');
       expect(results['left']['term_min']).to.equal('20020101');
       expect(results['left']['term_max']).to.equal('20030101');
-      expect(results['left']['inclusive']).to.equal(true);
+      expect(results['left']['inclusive']).to.equal('both');
     });
 
     it('parses example: title:{Aida TO Carmen}', () => {
@@ -402,7 +429,7 @@ describe('queryParser', () => {
       expect(results['left']['field']).to.equal('title');
       expect(results['left']['term_min']).to.equal('Aida');
       expect(results['left']['term_max']).to.equal('Carmen');
-      expect(results['left']['inclusive']).to.equal(false);
+      expect(results['left']['inclusive']).to.equal('none');
     });
 
     it('parses example: jakarta apache', () => {

--- a/test/toString_test.js
+++ b/test/toString_test.js
@@ -139,6 +139,18 @@ describe('toString', () => {
     testStr('foo:{bar TO baz}');
   });
 
+  it('must support mixed range expressions (left inclusive)', () => {
+    testStr('foo:[bar TO baz}');
+  });
+
+  it('must support mixed range expressions (right inclusive)', () => {
+    testStr('foo:{bar TO baz]');
+  });
+
+  it('must support mixed range expressions (right inclusive) with date ISO format', () => {
+    testStr('date:{2017-11-17T01:32:45.123Z TO 2017-11-18T04:28:11.999Z]');
+  });
+
   it('must support lucene example: title:"The Right Way" AND text:go', () => {
     testStr('title:"The Right Way" AND text:go');
   });


### PR DESCRIPTION
Don't know if everything is in place... automated tests seems to hold. Probably not the most elegant and effective solution on on the peg grammar but.. it was my first time and I just copy pasted (don't know anything about PEG syntax).

I've added for both parse and to_string:
- support to mixed inclusive/exclusive range delimiters
- support to ranged terms with semicolon for date ISO format

with their relative tests too.

Please review :)