### PR TITLE
support grammer whitespace between colon(:) and term; support lowerca…

### DIFF
--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -369,11 +369,26 @@ operator
   / 'OR'
   / 'AND'
   / 'NOT'
-  // 'or not'
+  / 'or not'
+    {
+      return 'OR NOT';
+    }
   / 'and not'
+    {
+      return 'AND NOT';
+    }
   / 'or'
+    {
+      return 'OR';
+    }
   / 'and'
+    {
+      return 'AND';
+    }
   / 'not'
+    {
+      return 'NOT';
+    }
   / '||'
   / '&&'
   / '!'

--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -6,6 +6,7 @@
  *
  * Supported features:
  * - conjunction operators (AND, OR, ||, &&, NOT, AND NOT, OR NOT)
+ * - conjunction operators (and, or, not, and not, or not)
  * - prefix operators (+, -)
  * - quoted values ("foo bar")
  * - named fields (foo:bar)
@@ -190,7 +191,7 @@ field_exp
     }
 
 fieldname
-  = fieldname:unquoted_term [:]
+  = fieldname:unquoted_term [:] _*
     {
         return fieldname;
     }
@@ -368,6 +369,11 @@ operator
   / 'OR'
   / 'AND'
   / 'NOT'
+  // 'or not'
+  / 'and not'
+  / 'or'
+  / 'and'
+  / 'not'
   / '||'
   / '&&'
   / '!'

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -279,21 +279,38 @@ module.exports = (function() {
         peg$c92 = { type: "literal", value: "AND", description: "\"AND\"" },
         peg$c93 = "NOT",
         peg$c94 = { type: "literal", value: "NOT", description: "\"NOT\"" },
-        peg$c95 = "and not",
-        peg$c96 = { type: "literal", value: "and not", description: "\"and not\"" },
-        peg$c97 = "or",
-        peg$c98 = { type: "literal", value: "or", description: "\"or\"" },
-        peg$c99 = "and",
-        peg$c100 = { type: "literal", value: "and", description: "\"and\"" },
-        peg$c101 = "not",
-        peg$c102 = { type: "literal", value: "not", description: "\"not\"" },
-        peg$c103 = "||",
-        peg$c104 = { type: "literal", value: "||", description: "\"||\"" },
-        peg$c105 = "&&",
-        peg$c106 = { type: "literal", value: "&&", description: "\"&&\"" },
-        peg$c107 = { type: "other", description: "whitespace" },
-        peg$c108 = /^[ \t\r\n\f]/,
-        peg$c109 = { type: "class", value: "[ \\t\\r\\n\\f]", description: "[ \\t\\r\\n\\f]" },
+        peg$c95 = "or not",
+        peg$c96 = { type: "literal", value: "or not", description: "\"or not\"" },
+        peg$c97 = function() {
+              return 'OR NOT';
+            },
+        peg$c98 = "and not",
+        peg$c99 = { type: "literal", value: "and not", description: "\"and not\"" },
+        peg$c100 = function() {
+              return 'AND NOT';
+            },
+        peg$c101 = "or",
+        peg$c102 = { type: "literal", value: "or", description: "\"or\"" },
+        peg$c103 = function() {
+              return 'OR';
+            },
+        peg$c104 = "and",
+        peg$c105 = { type: "literal", value: "and", description: "\"and\"" },
+        peg$c106 = function() {
+              return 'AND';
+            },
+        peg$c107 = "not",
+        peg$c108 = { type: "literal", value: "not", description: "\"not\"" },
+        peg$c109 = function() {
+              return 'NOT';
+            },
+        peg$c110 = "||",
+        peg$c111 = { type: "literal", value: "||", description: "\"||\"" },
+        peg$c112 = "&&",
+        peg$c113 = { type: "literal", value: "&&", description: "\"&&\"" },
+        peg$c114 = { type: "other", description: "whitespace" },
+        peg$c115 = /^[ \t\r\n\f]/,
+        peg$c116 = { type: "class", value: "[ \\t\\r\\n\\f]", description: "[ \\t\\r\\n\\f]" },
 
         peg$currPos          = 0,
         peg$reportedPos      = 0,
@@ -1904,7 +1921,7 @@ module.exports = (function() {
     }
 
     function peg$parseoperator() {
-      var s0;
+      var s0, s1;
 
       if (input.substr(peg$currPos, 6) === peg$c85) {
         s0 = peg$c85;
@@ -1946,60 +1963,99 @@ module.exports = (function() {
                 if (peg$silentFails === 0) { peg$fail(peg$c94); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 7) === peg$c95) {
-                  s0 = peg$c95;
-                  peg$currPos += 7;
+                s0 = peg$currPos;
+                if (input.substr(peg$currPos, 6) === peg$c95) {
+                  s1 = peg$c95;
+                  peg$currPos += 6;
                 } else {
-                  s0 = peg$FAILED;
+                  s1 = peg$FAILED;
                   if (peg$silentFails === 0) { peg$fail(peg$c96); }
                 }
+                if (s1 !== peg$FAILED) {
+                  peg$reportedPos = s0;
+                  s1 = peg$c97();
+                }
+                s0 = s1;
                 if (s0 === peg$FAILED) {
-                  if (input.substr(peg$currPos, 2) === peg$c97) {
-                    s0 = peg$c97;
-                    peg$currPos += 2;
+                  s0 = peg$currPos;
+                  if (input.substr(peg$currPos, 7) === peg$c98) {
+                    s1 = peg$c98;
+                    peg$currPos += 7;
                   } else {
-                    s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c98); }
+                    s1 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c99); }
                   }
+                  if (s1 !== peg$FAILED) {
+                    peg$reportedPos = s0;
+                    s1 = peg$c100();
+                  }
+                  s0 = s1;
                   if (s0 === peg$FAILED) {
-                    if (input.substr(peg$currPos, 3) === peg$c99) {
-                      s0 = peg$c99;
-                      peg$currPos += 3;
+                    s0 = peg$currPos;
+                    if (input.substr(peg$currPos, 2) === peg$c101) {
+                      s1 = peg$c101;
+                      peg$currPos += 2;
                     } else {
-                      s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                      s1 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c102); }
                     }
+                    if (s1 !== peg$FAILED) {
+                      peg$reportedPos = s0;
+                      s1 = peg$c103();
+                    }
+                    s0 = s1;
                     if (s0 === peg$FAILED) {
-                      if (input.substr(peg$currPos, 3) === peg$c101) {
-                        s0 = peg$c101;
+                      s0 = peg$currPos;
+                      if (input.substr(peg$currPos, 3) === peg$c104) {
+                        s1 = peg$c104;
                         peg$currPos += 3;
                       } else {
-                        s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                        s1 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c105); }
                       }
+                      if (s1 !== peg$FAILED) {
+                        peg$reportedPos = s0;
+                        s1 = peg$c106();
+                      }
+                      s0 = s1;
                       if (s0 === peg$FAILED) {
-                        if (input.substr(peg$currPos, 2) === peg$c103) {
-                          s0 = peg$c103;
-                          peg$currPos += 2;
+                        s0 = peg$currPos;
+                        if (input.substr(peg$currPos, 3) === peg$c107) {
+                          s1 = peg$c107;
+                          peg$currPos += 3;
                         } else {
-                          s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c104); }
+                          s1 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c108); }
                         }
+                        if (s1 !== peg$FAILED) {
+                          peg$reportedPos = s0;
+                          s1 = peg$c109();
+                        }
+                        s0 = s1;
                         if (s0 === peg$FAILED) {
-                          if (input.substr(peg$currPos, 2) === peg$c105) {
-                            s0 = peg$c105;
+                          if (input.substr(peg$currPos, 2) === peg$c110) {
+                            s0 = peg$c110;
                             peg$currPos += 2;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c106); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c111); }
                           }
                           if (s0 === peg$FAILED) {
-                            if (input.charCodeAt(peg$currPos) === 33) {
-                              s0 = peg$c43;
-                              peg$currPos++;
+                            if (input.substr(peg$currPos, 2) === peg$c112) {
+                              s0 = peg$c112;
+                              peg$currPos += 2;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c113); }
+                            }
+                            if (s0 === peg$FAILED) {
+                              if (input.charCodeAt(peg$currPos) === 33) {
+                                s0 = peg$c43;
+                                peg$currPos++;
+                              } else {
+                                s0 = peg$FAILED;
+                                if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                              }
                             }
                           }
                         }
@@ -2072,22 +2128,22 @@ module.exports = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c108.test(input.charAt(peg$currPos))) {
+      if (peg$c115.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c109); }
+        if (peg$silentFails === 0) { peg$fail(peg$c116); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c108.test(input.charAt(peg$currPos))) {
+          if (peg$c115.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c109); }
+            if (peg$silentFails === 0) { peg$fail(peg$c116); }
           }
         }
       } else {
@@ -2096,7 +2152,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c107); }
+        if (peg$silentFails === 0) { peg$fail(peg$c114); }
       }
 
       return s0;

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -279,13 +279,21 @@ module.exports = (function() {
         peg$c92 = { type: "literal", value: "AND", description: "\"AND\"" },
         peg$c93 = "NOT",
         peg$c94 = { type: "literal", value: "NOT", description: "\"NOT\"" },
-        peg$c95 = "||",
-        peg$c96 = { type: "literal", value: "||", description: "\"||\"" },
-        peg$c97 = "&&",
-        peg$c98 = { type: "literal", value: "&&", description: "\"&&\"" },
-        peg$c99 = { type: "other", description: "whitespace" },
-        peg$c100 = /^[ \t\r\n\f]/,
-        peg$c101 = { type: "class", value: "[ \\t\\r\\n\\f]", description: "[ \\t\\r\\n\\f]" },
+        peg$c95 = "and not",
+        peg$c96 = { type: "literal", value: "and not", description: "\"and not\"" },
+        peg$c97 = "or",
+        peg$c98 = { type: "literal", value: "or", description: "\"or\"" },
+        peg$c99 = "and",
+        peg$c100 = { type: "literal", value: "and", description: "\"and\"" },
+        peg$c101 = "not",
+        peg$c102 = { type: "literal", value: "not", description: "\"not\"" },
+        peg$c103 = "||",
+        peg$c104 = { type: "literal", value: "||", description: "\"||\"" },
+        peg$c105 = "&&",
+        peg$c106 = { type: "literal", value: "&&", description: "\"&&\"" },
+        peg$c107 = { type: "other", description: "whitespace" },
+        peg$c108 = /^[ \t\r\n\f]/,
+        peg$c109 = { type: "class", value: "[ \\t\\r\\n\\f]", description: "[ \\t\\r\\n\\f]" },
 
         peg$currPos          = 0,
         peg$reportedPos      = 0,
@@ -786,7 +794,7 @@ module.exports = (function() {
     }
 
     function peg$parsefieldname() {
-      var s0, s1, s2;
+      var s0, s1, s2, s3, s4;
 
       s0 = peg$currPos;
       s1 = peg$parseunquoted_term();
@@ -799,9 +807,20 @@ module.exports = (function() {
           if (peg$silentFails === 0) { peg$fail(peg$c19); }
         }
         if (s2 !== peg$FAILED) {
-          peg$reportedPos = s0;
-          s1 = peg$c20(s1);
-          s0 = s1;
+          s3 = [];
+          s4 = peg$parse_();
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$parse_();
+          }
+          if (s3 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c20(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c0;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$c0;
@@ -1927,9 +1946,9 @@ module.exports = (function() {
                 if (peg$silentFails === 0) { peg$fail(peg$c94); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c95) {
+                if (input.substr(peg$currPos, 7) === peg$c95) {
                   s0 = peg$c95;
-                  peg$currPos += 2;
+                  peg$currPos += 7;
                 } else {
                   s0 = peg$FAILED;
                   if (peg$silentFails === 0) { peg$fail(peg$c96); }
@@ -1943,12 +1962,48 @@ module.exports = (function() {
                     if (peg$silentFails === 0) { peg$fail(peg$c98); }
                   }
                   if (s0 === peg$FAILED) {
-                    if (input.charCodeAt(peg$currPos) === 33) {
-                      s0 = peg$c43;
-                      peg$currPos++;
+                    if (input.substr(peg$currPos, 3) === peg$c99) {
+                      s0 = peg$c99;
+                      peg$currPos += 3;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                    }
+                    if (s0 === peg$FAILED) {
+                      if (input.substr(peg$currPos, 3) === peg$c101) {
+                        s0 = peg$c101;
+                        peg$currPos += 3;
+                      } else {
+                        s0 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c102); }
+                      }
+                      if (s0 === peg$FAILED) {
+                        if (input.substr(peg$currPos, 2) === peg$c103) {
+                          s0 = peg$c103;
+                          peg$currPos += 2;
+                        } else {
+                          s0 = peg$FAILED;
+                          if (peg$silentFails === 0) { peg$fail(peg$c104); }
+                        }
+                        if (s0 === peg$FAILED) {
+                          if (input.substr(peg$currPos, 2) === peg$c105) {
+                            s0 = peg$c105;
+                            peg$currPos += 2;
+                          } else {
+                            s0 = peg$FAILED;
+                            if (peg$silentFails === 0) { peg$fail(peg$c106); }
+                          }
+                          if (s0 === peg$FAILED) {
+                            if (input.charCodeAt(peg$currPos) === 33) {
+                              s0 = peg$c43;
+                              peg$currPos++;
+                            } else {
+                              s0 = peg$FAILED;
+                              if (peg$silentFails === 0) { peg$fail(peg$c44); }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -2017,22 +2072,22 @@ module.exports = (function() {
 
       peg$silentFails++;
       s0 = [];
-      if (peg$c100.test(input.charAt(peg$currPos))) {
+      if (peg$c108.test(input.charAt(peg$currPos))) {
         s1 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c101); }
+        if (peg$silentFails === 0) { peg$fail(peg$c109); }
       }
       if (s1 !== peg$FAILED) {
         while (s1 !== peg$FAILED) {
           s0.push(s1);
-          if (peg$c100.test(input.charAt(peg$currPos))) {
+          if (peg$c108.test(input.charAt(peg$currPos))) {
             s1 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c109); }
           }
         }
       } else {
@@ -2041,7 +2096,7 @@ module.exports = (function() {
       peg$silentFails--;
       if (s0 === peg$FAILED) {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        if (peg$silentFails === 0) { peg$fail(peg$c107); }
       }
 
       return s0;

--- a/lib/toString.js
+++ b/lib/toString.js
@@ -36,7 +36,7 @@ module.exports = function toString(ast) {
     }
 
     if (ast.operator !== implicit) {
-      result += ast.operator;
+      result += ast.operator.toUpperCase();
     }
   }
 

--- a/lib/toString.js
+++ b/lib/toString.js
@@ -36,7 +36,7 @@ module.exports = function toString(ast) {
     }
 
     if (ast.operator !== implicit) {
-      result += ast.operator.toUpperCase();
+      result += ast.operator;
     }
   }
 

--- a/test/queryParser_test.js
+++ b/test/queryParser_test.js
@@ -26,6 +26,13 @@ describe('queryParser', () => {
       expect(results['left']['term']).to.equal('Foo');
     });
 
+    it('handles whitespace between colon and term', () => {
+      var results = lucene.parse('foo: bar');
+
+      expect(results['left']['field']).to.equal('foo');
+      expect(results['left']['term']).to.equal('bar');
+    });
+
     function isEmpty(arr) {
       for (var i in arr) {
         return false;
@@ -198,6 +205,37 @@ describe('queryParser', () => {
 
       expect(results['left']['term']).to.equal('fizz');
       expect(results['operator']).to.equal('NOT');
+      expect(results['right']['term']).to.equal('buzz');
+    });
+
+    it('parses implicit conjunction operator (or)', () => {
+      var results = lucene.parse('fizz buzz');
+      expect(results['left']['term']).to.equal('fizz');
+      expect(results['operator']).to.equal('<implicit>');
+      expect(results['right']['term']).to.equal('buzz');
+    });
+
+    it('parses explicit conjunction operator (and)', () => {
+      var results = lucene.parse('fizz and buzz');
+
+      expect(results['left']['term']).to.equal('fizz');
+      expect(results['operator']).to.equal('and');
+      expect(results['right']['term']).to.equal('buzz');
+    });
+
+    it('parses explicit conjunction operator (or)', () => {
+      var results = lucene.parse('fizz or buzz');
+
+      expect(results['left']['term']).to.equal('fizz');
+      expect(results['operator']).to.equal('or');
+      expect(results['right']['term']).to.equal('buzz');
+    });
+
+    it('parses explicit conjunction operator (not)', () => {
+      var results = lucene.parse('fizz not buzz');
+
+      expect(results['left']['term']).to.equal('fizz');
+      expect(results['operator']).to.equal('not');
       expect(results['right']['term']).to.equal('buzz');
     });
 

--- a/test/queryParser_test.js
+++ b/test/queryParser_test.js
@@ -219,7 +219,7 @@ describe('queryParser', () => {
       var results = lucene.parse('fizz and buzz');
 
       expect(results['left']['term']).to.equal('fizz');
-      expect(results['operator']).to.equal('and');
+      expect(results['operator']).to.equal('AND');
       expect(results['right']['term']).to.equal('buzz');
     });
 
@@ -227,7 +227,7 @@ describe('queryParser', () => {
       var results = lucene.parse('fizz or buzz');
 
       expect(results['left']['term']).to.equal('fizz');
-      expect(results['operator']).to.equal('or');
+      expect(results['operator']).to.equal('OR');
       expect(results['right']['term']).to.equal('buzz');
     });
 
@@ -235,7 +235,7 @@ describe('queryParser', () => {
       var results = lucene.parse('fizz not buzz');
 
       expect(results['left']['term']).to.equal('fizz');
-      expect(results['operator']).to.equal('not');
+      expect(results['operator']).to.equal('NOT');
       expect(results['right']['term']).to.equal('buzz');
     });
 

--- a/test/toString_test.js
+++ b/test/toString_test.js
@@ -115,6 +115,18 @@ describe('toString', () => {
     testStr('fizz NOT buzz');
   });
 
+  it('must support explicit conjunction operators (or)', () => {
+    testStr('fizz or buzz', 'fizz OR buzz');
+  });
+
+  it('must support explicit conjunction operators (and)', () => {
+    testStr('fizz and buzz', 'fizz AND buzz');
+  });
+
+  it('must support explicit conjunction operators (not)', () => {
+    testStr('fizz not buzz', 'fizz NOT buzz');
+  });
+
   it('must support explicit conjunction operators (&&)', () => {
     testStr('fizz && buzz');
   });


### PR DESCRIPTION
added two pieces:

1. support grammer whitespace between colon(:) and term; 
2. support lowercase conjunction operators (and, or, not)

```javascript
const query = 'hello: world and ok: true'
```