### PR TITLE
support grammer whitespace between colon(:) and term

### DIFF
--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -190,7 +190,7 @@ field_exp
     }
 
 fieldname
-  = fieldname:unquoted_term [:]
+  = fieldname:unquoted_term [:] _*
     {
         return fieldname;
     }

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -786,7 +786,7 @@ module.exports = (function() {
     }
 
     function peg$parsefieldname() {
-      var s0, s1, s2;
+      var s0, s1, s2, s3, s4;
 
       s0 = peg$currPos;
       s1 = peg$parseunquoted_term();
@@ -799,9 +799,20 @@ module.exports = (function() {
           if (peg$silentFails === 0) { peg$fail(peg$c19); }
         }
         if (s2 !== peg$FAILED) {
-          peg$reportedPos = s0;
-          s1 = peg$c20(s1);
-          s0 = s1;
+          s3 = [];
+          s4 = peg$parse_();
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$parse_();
+          }
+          if (s3 !== peg$FAILED) {
+            peg$reportedPos = s0;
+            s1 = peg$c20(s1);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c0;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$c0;

--- a/test/queryParser_test.js
+++ b/test/queryParser_test.js
@@ -26,6 +26,13 @@ describe('queryParser', () => {
       expect(results['left']['term']).to.equal('Foo');
     });
 
+    it('handles whitespace between colon and term', () => {
+      var results = lucene.parse('foo: bar');
+
+      expect(results['left']['field']).to.equal('foo');
+      expect(results['left']['term']).to.equal('bar');
+    });
+
     function isEmpty(arr) {
       for (var i in arr) {
         return false;


### PR DESCRIPTION

```javascript
const query = 'hello: world'
```