### PR TITLE
support no space before operator and left paren

### DIFF
--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -357,6 +357,10 @@ operator_exp
     {
         return operator;
     }
+  / _* operator:operator &"("
+    {
+        return operator;
+    }
   / _* operator:operator EOF
     {
         return operator;

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -1873,7 +1873,22 @@ module.exports = (function() {
         if (s1 !== peg$FAILED) {
           s2 = peg$parseoperator();
           if (s2 !== peg$FAILED) {
-            s3 = peg$parseEOF();
+            s3 = peg$currPos;
+            peg$silentFails++;
+            if (input.charCodeAt(peg$currPos) === 40) {
+              s4 = peg$c9;
+              peg$currPos++;
+            } else {
+              s4 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c10); }
+            }
+            peg$silentFails--;
+            if (s4 !== peg$FAILED) {
+              peg$currPos = s3;
+              s3 = peg$c33;
+            } else {
+              s3 = peg$c0;
+            }
             if (s3 !== peg$FAILED) {
               peg$reportedPos = s0;
               s1 = peg$c84(s2);
@@ -1889,6 +1904,35 @@ module.exports = (function() {
         } else {
           peg$currPos = s0;
           s0 = peg$c0;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$currPos;
+          s1 = [];
+          s2 = peg$parse_();
+          while (s2 !== peg$FAILED) {
+            s1.push(s2);
+            s2 = peg$parse_();
+          }
+          if (s1 !== peg$FAILED) {
+            s2 = peg$parseoperator();
+            if (s2 !== peg$FAILED) {
+              s3 = peg$parseEOF();
+              if (s3 !== peg$FAILED) {
+                peg$reportedPos = s0;
+                s1 = peg$c84(s2);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$c0;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$c0;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$c0;
+          }
         }
       }
 

--- a/test/queryParser_test.js
+++ b/test/queryParser_test.js
@@ -340,13 +340,13 @@ describe('queryParser', () => {
     */
 
     it('parses example: title:"The Right Way" NOT(text:go)', () => {
-      var results = lucene.parse('title:"The Right Way" AND text:go');
+      var results = lucene.parse('title:"The Right Way" NOT(text:go)');
 
       expect(results['left']['field']).to.equal('title');
       expect(results['left']['term']).to.equal('The Right Way');
-      expect(results['operator']).to.equal('AND');
-      expect(results['right']['field']).to.equal('text');
-      expect(results['right']['term']).to.equal('go');
+      expect(results['operator']).to.equal('NOT');
+      expect(results['right']['left']['field']).to.equal('text');
+      expect(results['right']['left']['term']).to.equal('go');
     });
 
     it('parses example: title:"The Right Way" AND text:go', () => {

--- a/test/queryParser_test.js
+++ b/test/queryParser_test.js
@@ -339,6 +339,16 @@ describe('queryParser', () => {
         title:(+return +"pink panther")
     */
 
+    it('parses example: title:"The Right Way" NOT(text:go)', () => {
+      var results = lucene.parse('title:"The Right Way" AND text:go');
+
+      expect(results['left']['field']).to.equal('title');
+      expect(results['left']['term']).to.equal('The Right Way');
+      expect(results['operator']).to.equal('AND');
+      expect(results['right']['field']).to.equal('text');
+      expect(results['right']['term']).to.equal('go');
+    });
+
     it('parses example: title:"The Right Way" AND text:go', () => {
       var results = lucene.parse('title:"The Right Way" AND text:go');
 

--- a/test/toString_test.js
+++ b/test/toString_test.js
@@ -247,6 +247,10 @@ describe('toString', () => {
     testStr('foo:"start \\" end"');
   });
 
+  it('must support lucene example: title:"The Right Way" AND(text:go)', () => {
+    testStr('title:"The Right Way" AND (text:go)');
+  });
+
   function testAst(ast, expected) {
     expect(lucene.toString(ast)).to.equal(expected);
   }


### PR DESCRIPTION


```javascript
NOT(text:go)
```