### PR TITLE
fix for quoted empty string

### DIFF
--- a/lib/toString.js
+++ b/lib/toString.js
@@ -51,7 +51,7 @@ module.exports = function toString(ast) {
     }
   }
 
-  if (ast.term) {
+  if (ast.term || (ast.term === '' && ast.quoted)) {
     if (ast.prefix) {
       result += ast.prefix;
     }


### PR DESCRIPTION
```js
{
    field: 'myfield',
    term: '',
    quoted: true
}
```
currently generates ```myfield:```

This pull request makes it generate ```myfield:""``` instead.
