### PR TITLE
[fix] supports "!" usage as prefix instead of operator

### DIFF
--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -397,7 +397,6 @@ operator
   / 'NOT'
   / '||'
   / '&&'
-  / '!'
 
 prefix_operator_exp
   = _* operator:prefix_operator
@@ -408,6 +407,7 @@ prefix_operator_exp
 prefix_operator
   = '+'
   / '-'
+  / '!'
 
 _ "whitespace"
   = [ \t\r\n\f]+

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -2141,15 +2141,6 @@ function peg$parse(input, options) {
                   s0 = peg$FAILED;
                   if (peg$silentFails === 0) { peg$fail(peg$c99); }
                 }
-                if (s0 === peg$FAILED) {
-                  if (input.charCodeAt(peg$currPos) === 33) {
-                    s0 = peg$c40;
-                    peg$currPos++;
-                  } else {
-                    s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c41); }
-                  }
-                }
               }
             }
           }
@@ -2205,6 +2196,15 @@ function peg$parse(input, options) {
       } else {
         s0 = peg$FAILED;
         if (peg$silentFails === 0) { peg$fail(peg$c39); }
+      }
+      if (s0 === peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 33) {
+          s0 = peg$c40;
+          peg$currPos++;
+        } else {
+          s0 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+        }
       }
     }
 

--- a/test/queryParser_test.js
+++ b/test/queryParser_test.js
@@ -78,6 +78,13 @@ describe('queryParser', () => {
       expect(results['left']['prefix']).to.equal('-');
     });
 
+    it('parses prefix operator (!)', () => {
+      var results = lucene.parse('!bar');
+
+      expect(results['left']['term']).to.equal('bar');
+      expect(results['left']['prefix']).to.equal('!');
+    });
+
     it('parses prefix operator (+)', () => {
       var results = lucene.parse('+bar');
 
@@ -90,6 +97,13 @@ describe('queryParser', () => {
 
       expect(results['left']['term']).to.equal('fizz buzz');
       expect(results['left']['prefix']).to.equal('-');
+    });
+
+    it('parses prefix operator on quoted term (!)', () => {
+      var results = lucene.parse('!"fizz buzz"');
+
+      expect(results['left']['term']).to.equal('fizz buzz');
+      expect(results['left']['prefix']).to.equal('!');
     });
 
     it('parses prefix operator on quoted term (+)', () => {


### PR DESCRIPTION
There must not be a space between the exclamation mark and the actual query : [https://www.timroes.de/elasticsearch-kibana-queries-in-depth-tutorial#exclusion-not-operator](https://www.timroes.de/elasticsearch-kibana-queries-in-depth-tutorial#exclusion-not-operator).