### PR TITLE
Adding basic support for regex terms

### DIFF
--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -10,6 +10,7 @@
  * - quoted values ("foo bar")
  * - named fields (foo:bar)
  * - range expressions (foo:[bar TO baz], foo:{bar TO baz})
+ * - regex expressions (/^f?o[1-5]o/)
  * - proximity search expressions ("foo bar"~5)
  * - boost expressions (foo^5, "foo bar"^5)
  * - fuzzy search expressions (foo~, foo~0.5)
@@ -37,6 +38,7 @@
  *     'field': string,         // field name
  *     'term': string,          // term value
  *     'quoted': boolean,       // whether or not the value was quoted in the input string
+ *     'regex': boolean,        // whether or not the value is a regex expression
  *     'prefix': string         // prefix operator (+/-) [OPTIONAL]
  *     'boost': float           // boost value, (value > 1 must be integer) [OPTIONAL]
  *     'similarity': float      // similarity value, (value must be > 0 and < 1) [OPTIONAL]
@@ -216,6 +218,7 @@ term
         var result = {
           'term': term,
           'quoted': true,
+          'regex' : false,
           'termLocation': location()
         };
 
@@ -234,11 +237,23 @@ term
 
         return result;
     }
+  / op:prefix_operator_exp? term:regex_term _*
+      {
+        var result = {
+          'term': term,
+          'quoted': false,
+          'regex': true,
+          'termLocation': location()
+        };
+
+        return result;
+    }
   / op:prefix_operator_exp? term:unquoted_term similarity:fuzzy_modifier? boost:boost_modifier? _*
     {
         var result = {
           'term': term.label,
           'quoted': false,
+          'regex': false,
           'termLocation': location()
         };
         if('' != similarity)
@@ -284,8 +299,15 @@ term_char
 quoted_term
   = '"' chars:DoubleStringCharacter* '"' { return chars.join(''); }
 
+regex_term
+  = '/' chars:RegexCharacter+ '/' { return chars.join('') }
+
 DoubleStringCharacter
   = !('"' / "\\") char:. { return char; }
+  / "\\" sequence:EscapeSequence { return '\\' + sequence; }
+
+RegexCharacter
+  = !('/' / "\\") char:. { return char; }
   / "\\" sequence:EscapeSequence { return '\\' + sequence; }
 
 EscapeSequence

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -254,6 +254,7 @@ function peg$parse(input, options) {
               var result = {
                 'term': term,
                 'quoted': true,
+                'regex' : false,
                 'termLocation': location()
               };
 
@@ -272,10 +273,21 @@ function peg$parse(input, options) {
 
               return result;
           },
-      peg$c19 = function(op, term, similarity, boost) {
+      peg$c19 = function(op, term) {
+              var result = {
+                'term': term,
+                'quoted': false,
+                'regex': true,
+                'termLocation': location()
+              };
+
+              return result;
+          },
+      peg$c20 = function(op, term, similarity, boost) {
               var result = {
                 'term': term.label,
                 'quoted': false,
+                'regex': false,
                 'termLocation': location()
               };
               if('' != similarity)
@@ -292,132 +304,133 @@ function peg$parse(input, options) {
               }
               return result;
           },
-      peg$c20 = "\\",
-      peg$c21 = peg$literalExpectation("\\", false),
-      peg$c22 = function(sequence) { return '\\' + sequence; },
-      peg$c23 = ".",
-      peg$c24 = peg$literalExpectation(".", false),
-      peg$c25 = /^[^ \t\r\n\f{}()"\/\^~[\]]/,
-      peg$c26 = peg$classExpectation([" ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
-      peg$c27 = function(term) {
+      peg$c21 = "\\",
+      peg$c22 = peg$literalExpectation("\\", false),
+      peg$c23 = function(sequence) { return '\\' + sequence; },
+      peg$c24 = ".",
+      peg$c25 = peg$literalExpectation(".", false),
+      peg$c26 = /^[^ \t\r\n\f{}()"\/\^~[\]]/,
+      peg$c27 = peg$classExpectation([" ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
+      peg$c28 = function(term) {
               return term.join('');
           },
-      peg$c28 = function(term) {
+      peg$c29 = function(term) {
               return {
                 label: term.join(''),
                 location: location(),
               };
           },
-      peg$c29 = /^[^: \t\r\n\f{}()"\/\^~[\]]/,
-      peg$c30 = peg$classExpectation([":", " ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
-      peg$c31 = "\"",
-      peg$c32 = peg$literalExpectation("\"", false),
-      peg$c33 = function(chars) { return chars.join(''); },
-      peg$c34 = peg$anyExpectation(),
-      peg$c35 = function(char) { return char; },
-      peg$c36 = "+",
-      peg$c37 = peg$literalExpectation("+", false),
-      peg$c38 = "-",
-      peg$c39 = peg$literalExpectation("-", false),
-      peg$c40 = "!",
-      peg$c41 = peg$literalExpectation("!", false),
-      peg$c42 = "{",
-      peg$c43 = peg$literalExpectation("{", false),
-      peg$c44 = "}",
-      peg$c45 = peg$literalExpectation("}", false),
-      peg$c46 = "[",
-      peg$c47 = peg$literalExpectation("[", false),
-      peg$c48 = "]",
-      peg$c49 = peg$literalExpectation("]", false),
-      peg$c50 = "^",
-      peg$c51 = peg$literalExpectation("^", false),
-      peg$c52 = "?",
-      peg$c53 = peg$literalExpectation("?", false),
-      peg$c54 = ":",
-      peg$c55 = peg$literalExpectation(":", false),
-      peg$c56 = "&",
-      peg$c57 = peg$literalExpectation("&", false),
-      peg$c58 = "|",
-      peg$c59 = peg$literalExpectation("|", false),
-      peg$c60 = "'",
-      peg$c61 = peg$literalExpectation("'", false),
-      peg$c62 = "/",
-      peg$c63 = peg$literalExpectation("/", false),
-      peg$c64 = "~",
-      peg$c65 = peg$literalExpectation("~", false),
-      peg$c66 = "*",
-      peg$c67 = peg$literalExpectation("*", false),
-      peg$c68 = " ",
-      peg$c69 = peg$literalExpectation(" ", false),
-      peg$c70 = function(proximity) {
+      peg$c30 = /^[^: \t\r\n\f{}()"\/\^~[\]]/,
+      peg$c31 = peg$classExpectation([":", " ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
+      peg$c32 = "\"",
+      peg$c33 = peg$literalExpectation("\"", false),
+      peg$c34 = function(chars) { return chars.join(''); },
+      peg$c35 = "/",
+      peg$c36 = peg$literalExpectation("/", false),
+      peg$c37 = function(chars) { return chars.join('') },
+      peg$c38 = peg$anyExpectation(),
+      peg$c39 = function(char) { return char; },
+      peg$c40 = "+",
+      peg$c41 = peg$literalExpectation("+", false),
+      peg$c42 = "-",
+      peg$c43 = peg$literalExpectation("-", false),
+      peg$c44 = "!",
+      peg$c45 = peg$literalExpectation("!", false),
+      peg$c46 = "{",
+      peg$c47 = peg$literalExpectation("{", false),
+      peg$c48 = "}",
+      peg$c49 = peg$literalExpectation("}", false),
+      peg$c50 = "[",
+      peg$c51 = peg$literalExpectation("[", false),
+      peg$c52 = "]",
+      peg$c53 = peg$literalExpectation("]", false),
+      peg$c54 = "^",
+      peg$c55 = peg$literalExpectation("^", false),
+      peg$c56 = "?",
+      peg$c57 = peg$literalExpectation("?", false),
+      peg$c58 = ":",
+      peg$c59 = peg$literalExpectation(":", false),
+      peg$c60 = "&",
+      peg$c61 = peg$literalExpectation("&", false),
+      peg$c62 = "|",
+      peg$c63 = peg$literalExpectation("|", false),
+      peg$c64 = "'",
+      peg$c65 = peg$literalExpectation("'", false),
+      peg$c66 = "~",
+      peg$c67 = peg$literalExpectation("~", false),
+      peg$c68 = "*",
+      peg$c69 = peg$literalExpectation("*", false),
+      peg$c70 = " ",
+      peg$c71 = peg$literalExpectation(" ", false),
+      peg$c72 = function(proximity) {
               return proximity;
           },
-      peg$c71 = function(boost) {
+      peg$c73 = function(boost) {
               return boost;
           },
-      peg$c72 = function(fuzziness) {
+      peg$c74 = function(fuzziness) {
               return fuzziness == '' || fuzziness == null ? 0.5 : fuzziness;
           },
-      peg$c73 = "0.",
-      peg$c74 = peg$literalExpectation("0.", false),
-      peg$c75 = /^[0-9]/,
-      peg$c76 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c77 = function(val) {
+      peg$c75 = "0.",
+      peg$c76 = peg$literalExpectation("0.", false),
+      peg$c77 = /^[0-9]/,
+      peg$c78 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c79 = function(val) {
               return parseFloat("0." + val.join(''));
           },
-      peg$c78 = function(val) {
+      peg$c80 = function(val) {
               return parseInt(val.join(''));
           },
-      peg$c79 = "TO",
-      peg$c80 = peg$literalExpectation("TO", false),
-      peg$c81 = function(term_min, term_max) {
+      peg$c81 = "TO",
+      peg$c82 = peg$literalExpectation("TO", false),
+      peg$c83 = function(term_min, term_max) {
               return {
                   'term_min': term_min,
                   'term_max': term_max,
                   'inclusive': 'both'
               };
           },
-      peg$c82 = function(term_min, term_max) {
+      peg$c84 = function(term_min, term_max) {
               return {
                   'term_min': term_min,
                   'term_max': term_max,
                   'inclusive': 'none'
               };
           },
-      peg$c83 = function(term_min, term_max) {
+      peg$c85 = function(term_min, term_max) {
               return {
                   'term_min': term_min,
                   'term_max': term_max,
                   'inclusive': 'left'
               };
           },
-      peg$c84 = function(term_min, term_max) {
+      peg$c86 = function(term_min, term_max) {
               return {
                   'term_min': term_min,
                   'term_max': term_max,
                   'inclusive': 'right'
               };
           },
-      peg$c85 = function(operator) {
+      peg$c87 = function(operator) {
               return operator;
           },
-      peg$c86 = "OR NOT",
-      peg$c87 = peg$literalExpectation("OR NOT", false),
-      peg$c88 = "AND NOT",
-      peg$c89 = peg$literalExpectation("AND NOT", false),
-      peg$c90 = "OR",
-      peg$c91 = peg$literalExpectation("OR", false),
-      peg$c92 = "AND",
-      peg$c93 = peg$literalExpectation("AND", false),
-      peg$c94 = "NOT",
-      peg$c95 = peg$literalExpectation("NOT", false),
-      peg$c96 = "||",
-      peg$c97 = peg$literalExpectation("||", false),
-      peg$c98 = "&&",
-      peg$c99 = peg$literalExpectation("&&", false),
-      peg$c100 = peg$otherExpectation("whitespace"),
-      peg$c101 = /^[ \t\r\n\f]/,
-      peg$c102 = peg$classExpectation([" ", "\t", "\r", "\n", "\f"], false, false),
+      peg$c88 = "OR NOT",
+      peg$c89 = peg$literalExpectation("OR NOT", false),
+      peg$c90 = "AND NOT",
+      peg$c91 = peg$literalExpectation("AND NOT", false),
+      peg$c92 = "OR",
+      peg$c93 = peg$literalExpectation("OR", false),
+      peg$c94 = "AND",
+      peg$c95 = peg$literalExpectation("AND", false),
+      peg$c96 = "NOT",
+      peg$c97 = peg$literalExpectation("NOT", false),
+      peg$c98 = "||",
+      peg$c99 = peg$literalExpectation("||", false),
+      peg$c100 = "&&",
+      peg$c101 = peg$literalExpectation("&&", false),
+      peg$c102 = peg$otherExpectation("whitespace"),
+      peg$c103 = /^[ \t\r\n\f]/,
+      peg$c104 = peg$classExpectation([" ", "\t", "\r", "\n", "\f"], false, false),
 
       peg$currPos          = 0,
       peg$savedPos         = 0,
@@ -996,28 +1009,63 @@ function peg$parse(input, options) {
         s1 = null;
       }
       if (s1 !== peg$FAILED) {
-        s2 = peg$parseunquoted_term();
+        s2 = peg$parseregex_term();
         if (s2 !== peg$FAILED) {
-          s3 = peg$parsefuzzy_modifier();
-          if (s3 === peg$FAILED) {
-            s3 = null;
+          s3 = [];
+          s4 = peg$parse_();
+          while (s4 !== peg$FAILED) {
+            s3.push(s4);
+            s4 = peg$parse_();
           }
           if (s3 !== peg$FAILED) {
-            s4 = peg$parseboost_modifier();
-            if (s4 === peg$FAILED) {
-              s4 = null;
+            peg$savedPos = s0;
+            s1 = peg$c19(s1, s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$parseprefix_operator_exp();
+        if (s1 === peg$FAILED) {
+          s1 = null;
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parseunquoted_term();
+          if (s2 !== peg$FAILED) {
+            s3 = peg$parsefuzzy_modifier();
+            if (s3 === peg$FAILED) {
+              s3 = null;
             }
-            if (s4 !== peg$FAILED) {
-              s5 = [];
-              s6 = peg$parse_();
-              while (s6 !== peg$FAILED) {
-                s5.push(s6);
-                s6 = peg$parse_();
+            if (s3 !== peg$FAILED) {
+              s4 = peg$parseboost_modifier();
+              if (s4 === peg$FAILED) {
+                s4 = null;
               }
-              if (s5 !== peg$FAILED) {
-                peg$savedPos = s0;
-                s1 = peg$c19(s1, s2, s3, s4);
-                s0 = s1;
+              if (s4 !== peg$FAILED) {
+                s5 = [];
+                s6 = peg$parse_();
+                while (s6 !== peg$FAILED) {
+                  s5.push(s6);
+                  s6 = peg$parse_();
+                }
+                if (s5 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c20(s1, s2, s3, s4);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -1034,9 +1082,6 @@ function peg$parse(input, options) {
           peg$currPos = s0;
           s0 = peg$FAILED;
         }
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
       }
     }
 
@@ -1048,17 +1093,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c20;
+      s1 = peg$c21;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+      if (peg$silentFails === 0) { peg$fail(peg$c22); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c22(s2);
+        s1 = peg$c23(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1070,19 +1115,19 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c23;
+        s0 = peg$c24;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c24); }
+        if (peg$silentFails === 0) { peg$fail(peg$c25); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c25.test(input.charAt(peg$currPos))) {
+        if (peg$c26.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c26); }
+          if (peg$silentFails === 0) { peg$fail(peg$c27); }
         }
       }
     }
@@ -1106,7 +1151,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c27(s1);
+      s1 = peg$c28(s1);
     }
     s0 = s1;
 
@@ -1129,7 +1174,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c28(s1);
+      s1 = peg$c29(s1);
     }
     s0 = s1;
 
@@ -1141,17 +1186,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 92) {
-      s1 = peg$c20;
+      s1 = peg$c21;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c21); }
+      if (peg$silentFails === 0) { peg$fail(peg$c22); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseEscapeSequence();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c22(s2);
+        s1 = peg$c23(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1163,19 +1208,19 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 46) {
-        s0 = peg$c23;
+        s0 = peg$c24;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c24); }
+        if (peg$silentFails === 0) { peg$fail(peg$c25); }
       }
       if (s0 === peg$FAILED) {
-        if (peg$c29.test(input.charAt(peg$currPos))) {
+        if (peg$c30.test(input.charAt(peg$currPos))) {
           s0 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c30); }
+          if (peg$silentFails === 0) { peg$fail(peg$c31); }
         }
       }
     }
@@ -1188,11 +1233,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s1 = peg$c31;
+      s1 = peg$c32;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c32); }
+      if (peg$silentFails === 0) { peg$fail(peg$c33); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1203,15 +1248,65 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 34) {
-          s3 = peg$c31;
+          s3 = peg$c32;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c32); }
+          if (peg$silentFails === 0) { peg$fail(peg$c33); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c33(s2);
+          s1 = peg$c34(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseregex_term() {
+    var s0, s1, s2, s3;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 47) {
+      s1 = peg$c35;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c36); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$parseRegexCharacter();
+      if (s3 !== peg$FAILED) {
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$parseRegexCharacter();
+        }
+      } else {
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 47) {
+          s3 = peg$c35;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c36); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c37(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1236,19 +1331,19 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     peg$silentFails++;
     if (input.charCodeAt(peg$currPos) === 34) {
-      s2 = peg$c31;
+      s2 = peg$c32;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c32); }
+      if (peg$silentFails === 0) { peg$fail(peg$c33); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 92) {
-        s2 = peg$c20;
+        s2 = peg$c21;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c21); }
+        if (peg$silentFails === 0) { peg$fail(peg$c22); }
       }
     }
     peg$silentFails--;
@@ -1264,11 +1359,11 @@ function peg$parse(input, options) {
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c34); }
+        if (peg$silentFails === 0) { peg$fail(peg$c38); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c35(s2);
+        s1 = peg$c39(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1281,17 +1376,94 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 92) {
-        s1 = peg$c20;
+        s1 = peg$c21;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c21); }
+        if (peg$silentFails === 0) { peg$fail(peg$c22); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseEscapeSequence();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c22(s2);
+          s1 = peg$c23(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseRegexCharacter() {
+    var s0, s1, s2;
+
+    s0 = peg$currPos;
+    s1 = peg$currPos;
+    peg$silentFails++;
+    if (input.charCodeAt(peg$currPos) === 47) {
+      s2 = peg$c35;
+      peg$currPos++;
+    } else {
+      s2 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c36); }
+    }
+    if (s2 === peg$FAILED) {
+      if (input.charCodeAt(peg$currPos) === 92) {
+        s2 = peg$c21;
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c22); }
+      }
+    }
+    peg$silentFails--;
+    if (s2 === peg$FAILED) {
+      s1 = void 0;
+    } else {
+      peg$currPos = s1;
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      if (input.length > peg$currPos) {
+        s2 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s2 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c38); }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c39(s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 92) {
+        s1 = peg$c21;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c22); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseEscapeSequence();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c23(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -1310,27 +1482,27 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 43) {
-      s0 = peg$c36;
+      s0 = peg$c40;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c37); }
+      if (peg$silentFails === 0) { peg$fail(peg$c41); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c38;
+        s0 = peg$c42;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+        if (peg$silentFails === 0) { peg$fail(peg$c43); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
-          s0 = peg$c40;
+          s0 = peg$c44;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+          if (peg$silentFails === 0) { peg$fail(peg$c45); }
         }
         if (s0 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 40) {
@@ -1350,131 +1522,131 @@ function peg$parse(input, options) {
             }
             if (s0 === peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 123) {
-                s0 = peg$c42;
+                s0 = peg$c46;
                 peg$currPos++;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c43); }
+                if (peg$silentFails === 0) { peg$fail(peg$c47); }
               }
               if (s0 === peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 125) {
-                  s0 = peg$c44;
+                  s0 = peg$c48;
                   peg$currPos++;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c45); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c49); }
                 }
                 if (s0 === peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 91) {
-                    s0 = peg$c46;
+                    s0 = peg$c50;
                     peg$currPos++;
                   } else {
                     s0 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c47); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c51); }
                   }
                   if (s0 === peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 93) {
-                      s0 = peg$c48;
+                      s0 = peg$c52;
                       peg$currPos++;
                     } else {
                       s0 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c53); }
                     }
                     if (s0 === peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 94) {
-                        s0 = peg$c50;
+                        s0 = peg$c54;
                         peg$currPos++;
                       } else {
                         s0 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c51); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c55); }
                       }
                       if (s0 === peg$FAILED) {
                         if (input.charCodeAt(peg$currPos) === 34) {
-                          s0 = peg$c31;
+                          s0 = peg$c32;
                           peg$currPos++;
                         } else {
                           s0 = peg$FAILED;
-                          if (peg$silentFails === 0) { peg$fail(peg$c32); }
+                          if (peg$silentFails === 0) { peg$fail(peg$c33); }
                         }
                         if (s0 === peg$FAILED) {
                           if (input.charCodeAt(peg$currPos) === 63) {
-                            s0 = peg$c52;
+                            s0 = peg$c56;
                             peg$currPos++;
                           } else {
                             s0 = peg$FAILED;
-                            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+                            if (peg$silentFails === 0) { peg$fail(peg$c57); }
                           }
                           if (s0 === peg$FAILED) {
                             if (input.charCodeAt(peg$currPos) === 58) {
-                              s0 = peg$c54;
+                              s0 = peg$c58;
                               peg$currPos++;
                             } else {
                               s0 = peg$FAILED;
-                              if (peg$silentFails === 0) { peg$fail(peg$c55); }
+                              if (peg$silentFails === 0) { peg$fail(peg$c59); }
                             }
                             if (s0 === peg$FAILED) {
                               if (input.charCodeAt(peg$currPos) === 92) {
-                                s0 = peg$c20;
+                                s0 = peg$c21;
                                 peg$currPos++;
                               } else {
                                 s0 = peg$FAILED;
-                                if (peg$silentFails === 0) { peg$fail(peg$c21); }
+                                if (peg$silentFails === 0) { peg$fail(peg$c22); }
                               }
                               if (s0 === peg$FAILED) {
                                 if (input.charCodeAt(peg$currPos) === 38) {
-                                  s0 = peg$c56;
+                                  s0 = peg$c60;
                                   peg$currPos++;
                                 } else {
                                   s0 = peg$FAILED;
-                                  if (peg$silentFails === 0) { peg$fail(peg$c57); }
+                                  if (peg$silentFails === 0) { peg$fail(peg$c61); }
                                 }
                                 if (s0 === peg$FAILED) {
                                   if (input.charCodeAt(peg$currPos) === 124) {
-                                    s0 = peg$c58;
+                                    s0 = peg$c62;
                                     peg$currPos++;
                                   } else {
                                     s0 = peg$FAILED;
-                                    if (peg$silentFails === 0) { peg$fail(peg$c59); }
+                                    if (peg$silentFails === 0) { peg$fail(peg$c63); }
                                   }
                                   if (s0 === peg$FAILED) {
                                     if (input.charCodeAt(peg$currPos) === 39) {
-                                      s0 = peg$c60;
+                                      s0 = peg$c64;
                                       peg$currPos++;
                                     } else {
                                       s0 = peg$FAILED;
-                                      if (peg$silentFails === 0) { peg$fail(peg$c61); }
+                                      if (peg$silentFails === 0) { peg$fail(peg$c65); }
                                     }
                                     if (s0 === peg$FAILED) {
                                       if (input.charCodeAt(peg$currPos) === 47) {
-                                        s0 = peg$c62;
+                                        s0 = peg$c35;
                                         peg$currPos++;
                                       } else {
                                         s0 = peg$FAILED;
-                                        if (peg$silentFails === 0) { peg$fail(peg$c63); }
+                                        if (peg$silentFails === 0) { peg$fail(peg$c36); }
                                       }
                                       if (s0 === peg$FAILED) {
                                         if (input.charCodeAt(peg$currPos) === 126) {
-                                          s0 = peg$c64;
+                                          s0 = peg$c66;
                                           peg$currPos++;
                                         } else {
                                           s0 = peg$FAILED;
-                                          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+                                          if (peg$silentFails === 0) { peg$fail(peg$c67); }
                                         }
                                         if (s0 === peg$FAILED) {
                                           if (input.charCodeAt(peg$currPos) === 42) {
-                                            s0 = peg$c66;
+                                            s0 = peg$c68;
                                             peg$currPos++;
                                           } else {
                                             s0 = peg$FAILED;
-                                            if (peg$silentFails === 0) { peg$fail(peg$c67); }
+                                            if (peg$silentFails === 0) { peg$fail(peg$c69); }
                                           }
                                           if (s0 === peg$FAILED) {
                                             if (input.charCodeAt(peg$currPos) === 32) {
-                                              s0 = peg$c68;
+                                              s0 = peg$c70;
                                               peg$currPos++;
                                             } else {
                                               s0 = peg$FAILED;
-                                              if (peg$silentFails === 0) { peg$fail(peg$c69); }
+                                              if (peg$silentFails === 0) { peg$fail(peg$c71); }
                                             }
                                           }
                                         }
@@ -1505,17 +1677,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 126) {
-      s1 = peg$c64;
+      s1 = peg$c66;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c65); }
+      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseint_exp();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c70(s2);
+        s1 = peg$c72(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1534,17 +1706,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 94) {
-      s1 = peg$c50;
+      s1 = peg$c54;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c55); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsedecimal_or_int_exp();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c71(s2);
+        s1 = peg$c73(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1563,11 +1735,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 126) {
-      s1 = peg$c64;
+      s1 = peg$c66;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c65); }
+      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parsedecimal_exp();
@@ -1576,7 +1748,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c72(s2);
+        s1 = peg$c74(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1605,31 +1777,31 @@ function peg$parse(input, options) {
     var s0, s1, s2, s3;
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c73) {
-      s1 = peg$c73;
+    if (input.substr(peg$currPos, 2) === peg$c75) {
+      s1 = peg$c75;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c74); }
+      if (peg$silentFails === 0) { peg$fail(peg$c76); }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
-      if (peg$c75.test(input.charAt(peg$currPos))) {
+      if (peg$c77.test(input.charAt(peg$currPos))) {
         s3 = input.charAt(peg$currPos);
         peg$currPos++;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c76); }
+        if (peg$silentFails === 0) { peg$fail(peg$c78); }
       }
       if (s3 !== peg$FAILED) {
         while (s3 !== peg$FAILED) {
           s2.push(s3);
-          if (peg$c75.test(input.charAt(peg$currPos))) {
+          if (peg$c77.test(input.charAt(peg$currPos))) {
             s3 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c76); }
+            if (peg$silentFails === 0) { peg$fail(peg$c78); }
           }
         }
       } else {
@@ -1637,7 +1809,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c77(s2);
+        s1 = peg$c79(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -1656,22 +1828,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = [];
-    if (peg$c75.test(input.charAt(peg$currPos))) {
+    if (peg$c77.test(input.charAt(peg$currPos))) {
       s2 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c76); }
+      if (peg$silentFails === 0) { peg$fail(peg$c78); }
     }
     if (s2 !== peg$FAILED) {
       while (s2 !== peg$FAILED) {
         s1.push(s2);
-        if (peg$c75.test(input.charAt(peg$currPos))) {
+        if (peg$c77.test(input.charAt(peg$currPos))) {
           s2 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c76); }
+          if (peg$silentFails === 0) { peg$fail(peg$c78); }
         }
       }
     } else {
@@ -1679,7 +1851,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c78(s1);
+      s1 = peg$c80(s1);
     }
     s0 = s1;
 
@@ -1691,11 +1863,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c46;
+      s1 = peg$c50;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+      if (peg$silentFails === 0) { peg$fail(peg$c51); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseranged_term();
@@ -1707,12 +1879,12 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
         }
         if (s3 !== peg$FAILED) {
-          if (input.substr(peg$currPos, 2) === peg$c79) {
-            s4 = peg$c79;
+          if (input.substr(peg$currPos, 2) === peg$c81) {
+            s4 = peg$c81;
             peg$currPos += 2;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c80); }
+            if (peg$silentFails === 0) { peg$fail(peg$c82); }
           }
           if (s4 !== peg$FAILED) {
             s5 = [];
@@ -1729,15 +1901,15 @@ function peg$parse(input, options) {
               s6 = peg$parseranged_term();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c48;
+                  s7 = peg$c52;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c53); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c81(s2, s6);
+                  s1 = peg$c83(s2, s6);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -1770,11 +1942,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 123) {
-        s1 = peg$c42;
+        s1 = peg$c46;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c43); }
+        if (peg$silentFails === 0) { peg$fail(peg$c47); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseranged_term();
@@ -1786,12 +1958,12 @@ function peg$parse(input, options) {
             s4 = peg$parse_();
           }
           if (s3 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c79) {
-              s4 = peg$c79;
+            if (input.substr(peg$currPos, 2) === peg$c81) {
+              s4 = peg$c81;
               peg$currPos += 2;
             } else {
               s4 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c80); }
+              if (peg$silentFails === 0) { peg$fail(peg$c82); }
             }
             if (s4 !== peg$FAILED) {
               s5 = [];
@@ -1808,15 +1980,15 @@ function peg$parse(input, options) {
                 s6 = peg$parseranged_term();
                 if (s6 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 125) {
-                    s7 = peg$c44;
+                    s7 = peg$c48;
                     peg$currPos++;
                   } else {
                     s7 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c45); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c49); }
                   }
                   if (s7 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c82(s2, s6);
+                    s1 = peg$c84(s2, s6);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -1849,11 +2021,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c46;
+          s1 = peg$c50;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c47); }
+          if (peg$silentFails === 0) { peg$fail(peg$c51); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parseranged_term();
@@ -1865,12 +2037,12 @@ function peg$parse(input, options) {
               s4 = peg$parse_();
             }
             if (s3 !== peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c79) {
-                s4 = peg$c79;
+              if (input.substr(peg$currPos, 2) === peg$c81) {
+                s4 = peg$c81;
                 peg$currPos += 2;
               } else {
                 s4 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c80); }
+                if (peg$silentFails === 0) { peg$fail(peg$c82); }
               }
               if (s4 !== peg$FAILED) {
                 s5 = [];
@@ -1887,15 +2059,15 @@ function peg$parse(input, options) {
                   s6 = peg$parseranged_term();
                   if (s6 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 125) {
-                      s7 = peg$c44;
+                      s7 = peg$c48;
                       peg$currPos++;
                     } else {
                       s7 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c45); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c49); }
                     }
                     if (s7 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c83(s2, s6);
+                      s1 = peg$c85(s2, s6);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -1928,11 +2100,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 123) {
-            s1 = peg$c42;
+            s1 = peg$c46;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c43); }
+            if (peg$silentFails === 0) { peg$fail(peg$c47); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parseranged_term();
@@ -1944,12 +2116,12 @@ function peg$parse(input, options) {
                 s4 = peg$parse_();
               }
               if (s3 !== peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c79) {
-                  s4 = peg$c79;
+                if (input.substr(peg$currPos, 2) === peg$c81) {
+                  s4 = peg$c81;
                   peg$currPos += 2;
                 } else {
                   s4 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c80); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c82); }
                 }
                 if (s4 !== peg$FAILED) {
                   s5 = [];
@@ -1966,15 +2138,15 @@ function peg$parse(input, options) {
                     s6 = peg$parseranged_term();
                     if (s6 !== peg$FAILED) {
                       if (input.charCodeAt(peg$currPos) === 93) {
-                        s7 = peg$c48;
+                        s7 = peg$c52;
                         peg$currPos++;
                       } else {
                         s7 = peg$FAILED;
-                        if (peg$silentFails === 0) { peg$fail(peg$c49); }
+                        if (peg$silentFails === 0) { peg$fail(peg$c53); }
                       }
                       if (s7 !== peg$FAILED) {
                         peg$savedPos = s0;
-                        s1 = peg$c84(s2, s6);
+                        s1 = peg$c86(s2, s6);
                         s0 = s1;
                       } else {
                         peg$currPos = s0;
@@ -2036,7 +2208,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c85(s2);
+          s1 = peg$c87(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2064,7 +2236,7 @@ function peg$parse(input, options) {
           s3 = peg$parseEOF();
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c85(s2);
+            s1 = peg$c87(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2086,60 +2258,60 @@ function peg$parse(input, options) {
   function peg$parseoperator() {
     var s0;
 
-    if (input.substr(peg$currPos, 6) === peg$c86) {
-      s0 = peg$c86;
+    if (input.substr(peg$currPos, 6) === peg$c88) {
+      s0 = peg$c88;
       peg$currPos += 6;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c87); }
+      if (peg$silentFails === 0) { peg$fail(peg$c89); }
     }
     if (s0 === peg$FAILED) {
-      if (input.substr(peg$currPos, 7) === peg$c88) {
-        s0 = peg$c88;
+      if (input.substr(peg$currPos, 7) === peg$c90) {
+        s0 = peg$c90;
         peg$currPos += 7;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c89); }
+        if (peg$silentFails === 0) { peg$fail(peg$c91); }
       }
       if (s0 === peg$FAILED) {
-        if (input.substr(peg$currPos, 2) === peg$c90) {
-          s0 = peg$c90;
+        if (input.substr(peg$currPos, 2) === peg$c92) {
+          s0 = peg$c92;
           peg$currPos += 2;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c91); }
+          if (peg$silentFails === 0) { peg$fail(peg$c93); }
         }
         if (s0 === peg$FAILED) {
-          if (input.substr(peg$currPos, 3) === peg$c92) {
-            s0 = peg$c92;
+          if (input.substr(peg$currPos, 3) === peg$c94) {
+            s0 = peg$c94;
             peg$currPos += 3;
           } else {
             s0 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c93); }
+            if (peg$silentFails === 0) { peg$fail(peg$c95); }
           }
           if (s0 === peg$FAILED) {
-            if (input.substr(peg$currPos, 3) === peg$c94) {
-              s0 = peg$c94;
+            if (input.substr(peg$currPos, 3) === peg$c96) {
+              s0 = peg$c96;
               peg$currPos += 3;
             } else {
               s0 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c95); }
+              if (peg$silentFails === 0) { peg$fail(peg$c97); }
             }
             if (s0 === peg$FAILED) {
-              if (input.substr(peg$currPos, 2) === peg$c96) {
-                s0 = peg$c96;
+              if (input.substr(peg$currPos, 2) === peg$c98) {
+                s0 = peg$c98;
                 peg$currPos += 2;
               } else {
                 s0 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c97); }
+                if (peg$silentFails === 0) { peg$fail(peg$c99); }
               }
               if (s0 === peg$FAILED) {
-                if (input.substr(peg$currPos, 2) === peg$c98) {
-                  s0 = peg$c98;
+                if (input.substr(peg$currPos, 2) === peg$c100) {
+                  s0 = peg$c100;
                   peg$currPos += 2;
                 } else {
                   s0 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c99); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c101); }
                 }
               }
             }
@@ -2165,7 +2337,7 @@ function peg$parse(input, options) {
       s2 = peg$parseprefix_operator();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c85(s2);
+        s1 = peg$c87(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -2183,27 +2355,27 @@ function peg$parse(input, options) {
     var s0;
 
     if (input.charCodeAt(peg$currPos) === 43) {
-      s0 = peg$c36;
+      s0 = peg$c40;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c37); }
+      if (peg$silentFails === 0) { peg$fail(peg$c41); }
     }
     if (s0 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s0 = peg$c38;
+        s0 = peg$c42;
         peg$currPos++;
       } else {
         s0 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c39); }
+        if (peg$silentFails === 0) { peg$fail(peg$c43); }
       }
       if (s0 === peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
-          s0 = peg$c40;
+          s0 = peg$c44;
           peg$currPos++;
         } else {
           s0 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+          if (peg$silentFails === 0) { peg$fail(peg$c45); }
         }
       }
     }
@@ -2216,22 +2388,22 @@ function peg$parse(input, options) {
 
     peg$silentFails++;
     s0 = [];
-    if (peg$c101.test(input.charAt(peg$currPos))) {
+    if (peg$c103.test(input.charAt(peg$currPos))) {
       s1 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c102); }
+      if (peg$silentFails === 0) { peg$fail(peg$c104); }
     }
     if (s1 !== peg$FAILED) {
       while (s1 !== peg$FAILED) {
         s0.push(s1);
-        if (peg$c101.test(input.charAt(peg$currPos))) {
+        if (peg$c103.test(input.charAt(peg$currPos))) {
           s1 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c102); }
+          if (peg$silentFails === 0) { peg$fail(peg$c104); }
         }
       }
     } else {
@@ -2240,7 +2412,7 @@ function peg$parse(input, options) {
     peg$silentFails--;
     if (s0 === peg$FAILED) {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c100); }
+      if (peg$silentFails === 0) { peg$fail(peg$c102); }
     }
 
     return s0;
@@ -2256,7 +2428,7 @@ function peg$parse(input, options) {
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c34); }
+      if (peg$silentFails === 0) { peg$fail(peg$c38); }
     }
     peg$silentFails--;
     if (s1 === peg$FAILED) {

--- a/lib/toString.js
+++ b/lib/toString.js
@@ -57,6 +57,10 @@ module.exports = function toString(ast) {
       result += '"';
       result += ast.term;
       result += '"';
+    } else if (ast.regex) {
+      result += '/';
+      result += ast.term;
+      result += '/';
     } else {
       result += ast.term;
     }

--- a/test/queryParser_test.js
+++ b/test/queryParser_test.js
@@ -48,12 +48,23 @@ describe('queryParser', () => {
       var results = lucene.parse('bar');
 
       expect(results['left']['term']).to.equal('bar');
+      expect(results['left']['quoted']).to.be.false;
+      expect(results['left']['regex']).to.be.false;
     });
 
     it('parses quoted terms', () => {
       var results = lucene.parse('"fizz buzz"');
 
       expect(results['left']['term']).to.equal('fizz buzz');
+      expect(results['left']['quoted']).to.be.true;
+      expect(results['left']['regex']).to.be.false;
+    });
+
+    it('parses regex terms', () => {
+      var results = lucene.parse('/f[A-z]?o*/');
+      expect(results['left']['term']).to.equal('f[A-z]?o*');
+      expect(results['left']['quoted']).to.be.false;
+      expect(results['left']['regex']).to.be.true;
     });
 
     it('accepts terms with \'-\'', () => {

--- a/test/toString_test.js
+++ b/test/toString_test.js
@@ -55,6 +55,10 @@ describe('toString', () => {
     testStr('created_at:>now+5d');
   });
 
+  it('must support regex terms', () => {
+    testStr('/^fizz b?u[A-z]/');
+  });
+
   it('must support prefix operators (-)', () => {
     testStr('-bar');
   });


### PR DESCRIPTION
The Apache Lucene java library supports regular expression queries. The lucene regex queries we use on our backend are reported as invalid by this library.

I added support for regex terms and some tests. Its working for us, maybe it can help others as well. Let me know if if this implementation needs any work!

For Reference:
https://lucene.apache.org/core/4_6_0/core/org/apache/lucene/search/RegexpQuery.html