### PR TITLE
Add basic pretty print

### DIFF
--- a/lib/lucene.js
+++ b/lib/lucene.js
@@ -5,6 +5,7 @@ var escaping = require('./escaping');
 
 exports.parse = queryParser.parse.bind(queryParser);
 exports.toString = require('./toString');
+exports.prettyPrint = require('./prettyPrint');
 
 exports.term = {
   escape: escaping.escape,

--- a/lib/prettyPrint.js
+++ b/lib/prettyPrint.js
@@ -1,0 +1,52 @@
+const toString = require('./toString');
+
+var implicit = '<implicit>';
+
+function generateSpace(indent) {
+  return Array(indent).fill(' ').join('');
+}
+
+function prettyPrint(ast, indent = 0) {
+  if (ast) {
+    if ('term' in ast) {
+      return toString(ast);
+    }
+
+    const spaces = generateSpace(indent);
+    const spacesPlus2 = generateSpace(indent + 2);
+
+    let prefix = '';
+    if (ast.field != null && ast.field !== implicit) {
+      if (ast.term_min != null) {
+        return toString(ast);
+      } else {
+        prefix += ast.field + ':';
+      }
+    }
+
+    if (ast.start != null) {
+      prefix += (ast.parenthesized ? `(\n${spacesPlus2}` : '') + ast.start + ' ';
+    }
+
+    if (ast.operator != null) {
+      const operator = ast.operator === implicit ? '' : ast.operator;
+      
+
+      if (ast.parenthesized) {
+        const startingParenthesis = ast.start != null ? `${prefix}`: `${prefix}(\n${spacesPlus2}`;
+        const inside = `${ast.left ? prettyPrint(ast.left, indent + 2) : ''}\n${spacesPlus2 + operator} ${prettyPrint(ast.right, indent + 2)}`;
+        return `${startingParenthesis}${inside}\n${spaces})`;
+      }
+
+      return `${prefix}${ast.left ? prettyPrint(ast.left, indent) : ''}\n${spaces + operator} ${prettyPrint(ast.right, indent)}`;
+    }
+    if (ast.parenthesized) {
+      return `${prefix}(${prettyPrint(ast.left, indent)})`;
+    } else {
+      return `${prefix}${prettyPrint(ast.left, indent)}`;
+    }
+  }
+  return '';
+}
+
+module.exports = prettyPrint;

--- a/test/prettyPrint_test.js
+++ b/test/prettyPrint_test.js
@@ -1,0 +1,297 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+const lucene = require('../');
+
+describe('prettyPrint', () => {
+  it('must handle empty ast', () => {
+    testAst(null, '');
+    testAst(undefined, '');
+    testAst(null, '');
+  });
+
+  it('must handle simple terms', () => {
+    testStr('bar');
+  });
+
+  it('must handle simple terms with explicit field name', () => {
+    testStr('foo:bar');
+  });
+
+  it('must handle simple terms with explicit field name in round parentheses', () => {
+    testStr('foo:(bar)');
+  });
+
+  it('must handle quoted terms', () => {
+    testStr('"fizz buz"');
+  });
+
+  it('must handle empty quoted terms', () => {
+    testStr('""');
+  });
+
+  it('must support field groups', () => {
+    testStr('foo:(bar OR baz)', 'foo:(\n  bar\n  OR baz\n)');
+  });
+
+  it('must support fuzzy', () => {
+    testStr('foo~0.6');
+  });
+
+  it('must support fuzzy without explicit similarity', () => {
+    testStr('foo~');
+  });
+
+  it('must drop default similarity value', () => {
+    testStr('foo~0.5', 'foo~');
+  });
+
+  it('must support terms with "-"', () => {
+    testStr('created_at:>now-5d');
+  });
+
+  it('must support terms with "+"', () => {
+    testStr('created_at:>now+5d');
+  });
+
+  it('must support regex terms', () => {
+    testStr('/^fizz b?u[A-z]/');
+  });
+
+  it('must support keyed regex terms', () => {
+    testStr('some.key:/[mh]otel/');
+  });
+
+  it('must support prefix operators (-)', () => {
+    testStr('-bar');
+  });
+
+  it('must support prefix operators (+)', () => {
+    testStr('+bar');
+  });
+
+  it('must support prefix operators (-) on quoted terms', () => {
+    testStr('-"fizz buzz"');
+  });
+
+  it('must support prefix operators (+) on quoted terms', () => {
+    testStr('+"fizz buzz"');
+  });
+
+  it('must support dates as terms', () => {
+    testStr('foo:2015-01-01');
+  });
+
+  it('must support dots in field names', () => {
+    testStr('sub.foo:bar');
+  });
+
+  it('must support quoted string with explicit field names', () => {
+    testStr('foo:"fizz buzz"');
+  });
+
+  it('must support empty quoted string with explicit field names', () => {
+    testStr('foo:""');
+  });
+
+  it('must support prefixes and explicit field names (-)', () => {
+    testStr('foo:-bar');
+  });
+
+  it('must support prefixes and explicit field names in round parentheses (-)', () => {
+    testStr('foo:(-bar)');
+  });
+
+  it('must support prefixes and explicit field names (+)', () => {
+    testStr('foo:+bar');
+  });
+
+  it('must support prefixes and explicit field names in round parentheses (+)', () => {
+    testStr('foo:(+bar)');
+  });
+
+  it('must support quoted prefixes', () => {
+    testStr('foo:-"fizz buzz"');
+  });
+
+  it('must support implicit conjunction operators', () => {
+    testStr('fizz buzz','fizz\n buzz');
+  });
+
+  it('must support explicit conjunction operators (OR)', () => {
+    testStr('fizz OR buzz','fizz\nOR buzz');
+  });
+
+  it('must support explicit conjunction operators (AND)', () => {
+    testStr('fizz AND buzz','fizz\nAND buzz');
+  });
+
+  it('must support explicit conjunction operators (NOT)', () => {
+    testStr('fizz NOT buzz','fizz\nNOT buzz');
+  });
+
+  it('must support explicit conjunction operators (&&)', () => {
+    testStr('fizz && buzz','fizz\n&& buzz');
+  });
+
+  it('must support explicit conjunction operators (||)', () => {
+    testStr('fizz || buzz','fizz\n|| buzz');
+  });
+
+  it('must support parentheses groups', () => {
+    testStr('fizz (buzz baz)','fizz\n (\n  buzz\n   baz\n)');
+  });
+
+  it('must support parentheses groups with explicit conjunction operators', () => {
+    testStr('fizz AND (buzz OR baz)','fizz\nAND (\n  buzz\n  OR baz\n)');
+  });
+
+  it('must support inclusive range expressions', () => {
+    testStr('foo:[bar TO baz]');
+  });
+
+  it('must support exclusive range expressions', () => {
+    testStr('foo:{bar TO baz}');
+  });
+
+  it('must support mixed range expressions (left inclusive)', () => {
+    testStr('foo:[bar TO baz}');
+  });
+
+  it('must support mixed range expressions (right inclusive)', () => {
+    testStr('foo:{bar TO baz]');
+  });
+
+  it('must support mixed range expressions (right inclusive) with date ISO format', () => {
+    testStr('date:{2017-11-17T01:32:45.123Z TO 2017-11-18T04:28:11.999Z]');
+  });
+
+  it('must support lucene example: title:"The Right Way" AND text:go', () => {
+    testStr('title:"The Right Way" AND text:go','title:"The Right Way"\nAND text:go');
+  });
+
+  it('must support lucene example: title:"Do it right" AND right', () => {
+    testStr('title:"Do it right" AND right', 'title:"Do it right"\nAND right');
+  });
+
+  it('must support lucene example: title:Do it right', () => {
+    testStr('title:Do it right', 'title:Do\n it\n right');
+  });
+
+  it('must support lucene example: te?t', () => {
+    testStr('te?t');
+  });
+
+  it('must support lucene example: test*', () => {
+    testStr('test*');
+  });
+
+  it('must support lucene example: te*t', () => {
+    testStr('te*t');
+  });
+
+  it('must support lucene example: roam~', () => {
+    testStr('roam~');
+  });
+
+  it('must support lucene example: roam~0.8', () => {
+    testStr('roam~0.8');
+  });
+
+  it('must support lucene example: "jakarta apache"~10', () => {
+    testStr('"jakarta apache"~10');
+  });
+
+  it('must support lucene example: mod_date:[20020101 TO 20030101]', () => {
+    testStr('mod_date:[20020101 TO 20030101]');
+  });
+
+  it('must support lucene example: title:{Aida TO Carmen}', () => {
+    testStr('title:{Aida TO Carmen}');
+  });
+
+  it('must support lucene example: jakarta apache', () => {
+    testStr('jakarta apache','jakarta\n apache');
+  });
+
+  it('must support lucene example: jakarta^4 apache', () => {
+    testStr('jakarta^4 apache', 'jakarta^4\n apache');
+  });
+
+  it('must support lucene example: "jakarta apache"^4 "Apache Lucene"', () => {
+    testStr('"jakarta apache"^4 "Apache Lucene"', '"jakarta apache"^4\n "Apache Lucene"');
+  });
+
+  it('must support lucene example: "jakarta apache" jakarta', () => {
+    testStr('"jakarta apache" jakarta','"jakarta apache"\n jakarta');
+  });
+
+  it('must support lucene example: "jakarta apache" OR jakarta', () => {
+    testStr('"jakarta apache" OR jakarta', '"jakarta apache"\nOR jakarta');
+  });
+
+  it('must support lucene example: "jakarta apache" AND "Apache Lucene"', () => {
+    testStr('"jakarta apache" AND "Apache Lucene"', '"jakarta apache"\nAND "Apache Lucene"');
+  });
+
+  it('must support lucene example: +jakarta lucene', () => {
+    testStr('+jakarta lucene','+jakarta\n lucene');
+  });
+
+  it('must support lucene example: "jakarta apache" NOT "Apache Lucene"', () => {
+    testStr('"jakarta apache" NOT "Apache Lucene"', '"jakarta apache"\nNOT "Apache Lucene"');
+  });
+
+  it('must support lucene example: NOT "jakarta apache"', () => {
+    testStr('NOT "jakarta apache"');
+  });
+
+  it('must support lucene example: "jakarta apache" -"Apache Lucene"', () => {
+    testStr('"jakarta apache" -"Apache Lucene"', '"jakarta apache"\n -"Apache Lucene"');
+  });
+
+  it('must support lucene example: (jakarta OR apache) AND website', () => {
+    testStr('(jakarta OR apache) AND website', '(\n  jakarta\n  OR apache\n)\nAND website');
+  });
+
+  it('must support lucene example: title:(+return +"pink panther")', () => {
+    testStr('title:(+return +"pink panther")', 'title:(\n  +return\n   +"pink panther"\n)');
+  });
+
+  it('must support strings with quotes', () => {
+    testStr('foo:"start \\" end"');
+  });
+
+  it('must support escaped characters', () => {
+    testStr('foo\\(\\)\\{\\}\\+\\~\\!\\?\\[\\]\\:\\*bar');
+  });
+
+  it('must support escaped whitespace', () => {
+    testStr('foo:a\\ b');
+  });
+
+  it('must support whitespace in parens', () => {
+    testStr('foo ( bar OR baz)', 'foo\n (\n  bar\n  OR baz\n)');
+  });
+
+  it('must support ! prefix operator', () => {
+    testStr('-author:adams');
+  });
+
+  it('must support parenthesized expressions with start set', () => {
+    testStr('prop:value1 AND (NOT _exists_:other OR other:value2)', 'prop:value1\nAND (\n  NOT _exists_:other\n  OR other:value2\n)');
+  });
+
+  it('must support parenthesized expressions with start set and not', () => {
+    testStr('prop:value1 AND (NOT _exists_:other OR other:value2)', 'prop:value1\nAND (\n  NOT _exists_:other\n  OR other:value2\n)');
+  });
+
+  function testAst(ast, expected) {
+    expect(lucene.prettyPrint(ast)).to.equal(expected, 'Got the following AST: ' + JSON.stringify(ast, 0, 2));
+  }
+
+  function testStr(str, expected) {
+    testAst(lucene.parse(str), expected != null ? expected : str);
+  }
+});


### PR DESCRIPTION
Added basic pretty print. Useful when people have complex queries to edit.
Main drawback I saw is that implicit OR is replaced by a space. Not sure if this should be changed or not, it's fine for my use.
Two-space indentation is not configurable, but it's easy to add.

Kept the code separate from the rest because it was easier to incorporate like that.