### PR TITLE
Allow quoted terms within a range expression

### DIFF
--- a/lib/lucene.grammar
+++ b/lib/lucene.grammar
@@ -277,10 +277,8 @@ rterm_char
 
 
 ranged_term
-  = term:rterm_char+
-    {
-        return term.join('');
-    }
+  = term:rterm_char+ { return term.join(''); }
+  / term:quoted_term
 
 unquoted_term
   = term:term_char+

--- a/lib/queryParser.js
+++ b/lib/queryParser.js
@@ -311,9 +311,7 @@ function peg$parse(input, options) {
       peg$c25 = peg$literalExpectation(".", false),
       peg$c26 = /^[^ \t\r\n\f{}()"\/\^~[\]]/,
       peg$c27 = peg$classExpectation([" ", "\t", "\r", "\n", "\f", "{", "}", "(", ")", "\"", "/", "^", "~", "[", "]"], true, false),
-      peg$c28 = function(term) {
-              return term.join('');
-          },
+      peg$c28 = function(term) { return term.join(''); },
       peg$c29 = function(term) {
               return {
                 label: term.join(''),
@@ -1154,6 +1152,9 @@ function peg$parse(input, options) {
       s1 = peg$c28(s1);
     }
     s0 = s1;
+    if (s0 === peg$FAILED) {
+      s0 = peg$parsequoted_term();
+    }
 
     return s0;
   }

--- a/test/queryParser_test.js
+++ b/test/queryParser_test.js
@@ -333,6 +333,13 @@ describe('queryParser', () => {
       expect(results['left']['term_max']).to.equal('2017-11-18T04:28:11.999Z');
       expect(results['left']['inclusive']).to.equal('right');
     });
+
+    it('parses a quoted term in a range expression', () => {
+      var results = lucene.parse('date:["3/daysAgo" TO Today]');
+      expect(results['left']['field']).to.equal('date');
+      expect(results['left']['term_min']).to.equal('3/daysAgo');
+      expect(results['left']['term_max']).to.equal('Today');
+    });
   });
 
   describe('Lucene Query syntax documentation examples', () => {


### PR DESCRIPTION
This change allows terms within a range expression to be quoted.

This works in our other tools and a we have a bunch of queries we'd like to use this library on.

This seemed like the simplest fix, but happy to make changes if it's not correct.