### PR TITLE
chore: remove the badge of David

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lucene &nbsp; [![Build Status](https://travis-ci.org/bripkens/lucene.svg?branch=master)](https://travis-ci.org/bripkens/lucene) [![Dependency Status](https://david-dm.org/bripkens/lucene/master.svg)](https://david-dm.org/bripkens/lucene/master) [![Coverage Status](https://img.shields.io/coveralls/bripkens/lucene.svg)](https://coveralls.io/r/bripkens/lucene?branch=master) [![npm version](https://badge.fury.io/js/lucene.svg)](https://badge.fury.io/js/lucene)
+# lucene &nbsp; [![Build Status](https://travis-ci.org/bripkens/lucene.svg?branch=master)](https://travis-ci.org/bripkens/lucene) [![Coverage Status](https://img.shields.io/coveralls/bripkens/lucene.svg)](https://coveralls.io/r/bripkens/lucene?branch=master) [![npm version](https://badge.fury.io/js/lucene.svg)](https://badge.fury.io/js/lucene)
 
 Parse, modify and stringify lucene queries.
 


### PR DESCRIPTION
Due to the unreliability of its service (alanshaw/david#171) and questionable necessity (https://depfu.com/blog/rethinking-the-dependencies-badge).

![9e81a57219d4b2d6eec4d60c80bd0d006de57c5f](https://user-images.githubusercontent.com/14012511/171143564-e8af1abc-1361-4608-b3bb-20c4b65710df.png)

> https://github.com/alanshaw/david/issues/182 https://github.com/alanshaw/david/issues/179